### PR TITLE
Set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+**xscout** is a Java CLI application that monitors the XRP Ledger transaction stream via WebSocket. There is no web UI, no database, and no Docker infrastructure.
+
+### Prerequisites
+- **Java 8+** (OpenJDK 21 is pre-installed on the VM)
+- **Apache Maven 3.x** (installed via `sudo apt-get install -y maven` during setup)
+
+### Build & Run
+- See `README.md` for the canonical run command: `mvn compile exec:java`
+- The app accepts an optional integer argument for transaction count: `mvn compile exec:java -Dexec.args="5"` (default: 100)
+- The application connects to `wss://fh.xrpl.ws` (public XRP Ledger WebSocket) and requires outbound internet access
+
+### Caveats
+- There are no automated tests in this project (no `src/test` directory)
+- There is no linter configured
+- The default run (`mvn compile exec:java`) collects 100 transactions before exiting, which can take a while depending on network activity. Use `-Dexec.args="N"` with a small number for quick verification.
+- First run after dependency resolution may take longer as Maven downloads exec-maven-plugin transitive dependencies at execution time


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development instructions for the xscout project.

### What was set up

- **Java 21** (OpenJDK, pre-installed) — compatible with Java 8 source/target
- **Apache Maven 3.8.7** — installed via apt for building and running the project
- Maven dependencies resolved and cached

### Verification

The application was built and run successfully:

- `mvn compile` — compiles all Java sources
- `mvn compile exec:java -Dexec.args="5"` — connects to the XRP Ledger WebSocket, receives live transactions (Payment, OfferCreate, TrustSet types), and exits after collecting 5 matching transactions

### Files changed

- `AGENTS.md` — New file with Cursor Cloud development instructions including build/run commands, prerequisites, and caveats

### Run output

[xscout_run_output.log](https://cursor.com/agents/bc-cc80558d-bde9-4c15-aef5-afee128dd190/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fxscout_run_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc80558d-bde9-4c15-aef5-afee128dd190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc80558d-bde9-4c15-aef5-afee128dd190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

