### PR TITLE
Add Docker image and ECS (EC2) deployment setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+**/__pycache__
+**/*.pyc
+.venv
+venv
+env
+.pytest_cache
+.mypy_cache
+.ruff_cache
+build
+dist
+*.egg-info
+*.log
+tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# xscout: stock watchlist CLI (runs once per container start; exit 0 on success)
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY xscout/ ./xscout/
+
+# Default matches README; override at run time, e.g. ECS task overrides or docker run args
+CMD ["python3", "-m", "xscout"]

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,82 @@
+# Deploy xscout to Amazon ECS (EC2 capacity)
+
+xscout is a one-shot CLI: the container should **start, print the table, and exit**. On ECS this fits **run-task** (ad hoc or on a schedule) better than a long-running service.
+
+These steps assume an **ECS cluster with EC2 container instances** already registered, and the AWS CLI configured for the target account and Region.
+
+## 1. Container instance IAM
+
+Each EC2 instance in the cluster needs an instance profile whose role allows at least:
+
+- `AmazonEC2ContainerServiceforEC2Role` (AWS managed policy for the ECS agent)
+- ECR read against your repository, for example managed policy `AmazonEC2ContainerRegistryReadOnly`
+- CloudWatch Logs write for the `awslogs` driver, for example managed policy `CloudWatchLogsFullAccess` (or a tighter custom policy for `/ecs/xscout`)
+
+Attach **no inbound rules** required for this app; outbound HTTPS to Yahoo Finance must be allowed (default security group with a route to the internet, or a NAT gateway, depending on your VPC).
+
+## 2. Build and push the image to ECR
+
+Replace `REGION` and `ACCOUNT_ID` as needed.
+
+```bash
+aws ecr create-repository --repository-name xscout --region REGION 2>/dev/null || true
+aws ecr get-login-password --region REGION | docker login --username AWS --password-stdin ACCOUNT_ID.dkr.ecr.REGION.amazonaws.com
+docker build -t xscout:latest .
+docker tag xscout:latest ACCOUNT_ID.dkr.ecr.REGION.amazonaws.com/xscout:latest
+docker push ACCOUNT_ID.dkr.ecr.REGION.amazonaws.com/xscout:latest
+```
+
+## 3. CloudWatch Logs
+
+Create the log group referenced by the task definition (once per Region):
+
+```bash
+aws logs create-log-group --log-group-name /ecs/xscout --region REGION 2>/dev/null || true
+```
+
+## 4. Register the task definition
+
+Edit `deploy/ecs-task-definition.json`: set `image`, `awslogs-region`, and all `<ACCOUNT_ID>` / `<REGION>` placeholders. Then:
+
+```bash
+aws ecs register-task-definition --cli-input-json file://deploy/ecs-task-definition.json --region REGION
+```
+
+Optional: pass CLI flags by setting `command` in the task definition, for example:
+
+```json
+"command": ["python3", "-m", "xscout", "--tickers=AAPL,MSFT", "--sort=marketcap", "--desc"]
+```
+
+Or use **container overrides** on `run-task` / EventBridge instead of editing the JSON.
+
+## 5. Run a one-off task on EC2 capacity
+
+List your cluster name and the **container instance** ARN (or use placement constraints if you have several):
+
+```bash
+aws ecs list-container-instances --cluster YOUR_CLUSTER --region REGION
+aws ecs run-task \
+  --cluster YOUR_CLUSTER \
+  --task-definition xscout \
+  --launch-type EC2 \
+  --placement-constraints type=memberOf,expression=attribute:ecs.instance-type =~ t3.* \
+  --region REGION
+```
+
+Omit `--placement-constraints` if the scheduler may place the task on any instance. For a single-instance dev cluster, placement is usually unnecessary.
+
+Inspect output in **CloudWatch Logs** under `/ecs/xscout`, or describe the stopped task:
+
+```bash
+aws ecs describe-tasks --cluster YOUR_CLUSTER --tasks TASK_ARN --region REGION
+```
+
+## 6. Optional: schedule with EventBridge
+
+Create a rule that invokes **ECS RunTask** on a cron schedule, with a target role allowed to `ecs:RunTask` and `iam:PassRole` on the task role (if any) and task execution role (if any). For this task definition (EC2, bridge, no task or execution roles), the EventBridge target role typically needs `ecs:RunTask` on your task definition ARN and permission to pass roles only if you add roles later.
+
+## Notes
+
+- **Fargate**: use `requiresCompatibilities` `FARGATE`, `networkMode` `awsvpc`, add `executionRoleArn`, `cpu`/`memory` at the task level, and omit EC2-only placement. This repo’s template targets **EC2** as requested.
+- **Networking**: the container needs outbound access to Yahoo Finance; corporate egress or missing NAT is a common cause of empty or skipped tickers.

--- a/deploy/ecs-task-definition.json
+++ b/deploy/ecs-task-definition.json
@@ -1,0 +1,22 @@
+{
+  "family": "xscout",
+  "networkMode": "bridge",
+  "requiresCompatibilities": ["EC2"],
+  "containerDefinitions": [
+    {
+      "name": "xscout",
+      "image": "<ACCOUNT_ID>.dkr.ecr.<REGION>.amazonaws.com/xscout:latest",
+      "essential": true,
+      "memory": 512,
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/xscout",
+          "awslogs-region": "<REGION>",
+          "awslogs-stream-prefix": "ecs"
+        }
+      },
+      "command": ["python3", "-m", "xscout"]
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change adds container packaging and a minimal path to run **xscout** on **Amazon ECS with EC2 capacity**: a `Dockerfile`, `.dockerignore`, an ECS task definition template with **awslogs**, and step-by-step notes under `deploy/README.md`.

## Why

The app is a one-shot CLI; ECS fits **run-task** (manual or scheduled) rather than a long-running service. The template uses **bridge** networking and **EC2** compatibility, which matches a typical EC2-backed ECS cluster.

## Notes for reviewers

- Placeholders in `deploy/ecs-task-definition.json` must be replaced with account ID and Region before `register-task-definition`.
- EC2 container instances need IAM permissions for the ECS agent, ECR pull, and CloudWatch Logs when using the `awslogs` driver (documented in `deploy/README.md`).
- Docker was not available in the CI VM here; the image should be validated with `docker build` locally or in your pipeline.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bfd8ad73-4735-4596-8cfa-723af2b8ecd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bfd8ad73-4735-4596-8cfa-723af2b8ecd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

