### PR TITLE
Postgres-backed ticker list library (L2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,7 @@ frontend/node_modules/
 build/
 dist/
 *.egg-info/
+
+# Local development database (when using a non-docker Postgres)
+.local/
 xscout/static/app/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,10 @@
 ## Cursor Cloud specific instructions
 
 **xscout** is a Python Flask stock watchlist application built on top of `yfinance`.
-It has no database. Saved ticker lists are stored in the browser via `localStorage`.
+Ticker lists are persisted in Postgres (table `ticker_lists`). The React Flow
+canvas layout (node positions, edges, viewport) is kept in `localStorage` in
+the browser. The repository's `xscout/migrations/*.sql` files are applied on
+startup, serialised by a Postgres advisory lock.
 
 ### Prerequisites
 - **Python 3.10+**
@@ -16,8 +19,11 @@ It has no database. Saved ticker lists are stored in the browser via `localStora
 - The canonical local run command is `.venv/bin/python -m xscout`
 - Run with Gunicorn using `.venv/bin/gunicorn xscout.app:app`
 - The application reads live Yahoo Finance data via `yfinance` and requires outbound internet access
+- `DATABASE_URL` must point to a Postgres instance (e.g. `postgresql://xscout:xscout@localhost:5432/xscout`).
+  Start the bundled local Postgres via `docker compose up -d postgres`. When `DATABASE_URL` is unset the ticker-list API returns 503; the rest of the app keeps working.
 
 ### Caveats
-- Automated tests use `.venv/bin/python -m unittest discover -s tests`
+- Automated tests use `.venv/bin/python -m unittest discover -s tests` and run **without** a database by default; the route layer mocks the repository.
+- Integration tests for `xscout/ticker_lists.py` are skipped unless `TEST_DATABASE_URL` is set; point it at the same docker-compose Postgres to enable them.
 - There is no linter configured
 - Network-dependent runs can fail or return partial data if Yahoo Finance throttles or changes upstream responses

--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@ It lets you arrange ticker lists on a React Flow canvas and displays:
 - Ticker
 - Current price
 - Market cap
-- Performance columns: **1D**, **5D**, **2W**, **1M**, **3M**
+- Performance columns: **1D**, **5D**, **2W**, **1M**, **3M**, **6M**, **1Y**, **5Y**
+
+Ticker lists are persisted in Postgres (one row per list). The canvas
+layout — node positions, edges, viewport — is kept in `localStorage`.
 
 The app fetches live market data from Yahoo Finance through the `yfinance` library.
 
@@ -13,6 +16,7 @@ The app fetches live market data from Yahoo Finance through the `yfinance` libra
 
 - Python 3.10+
 - Node.js 22+
+- Postgres 13+ (Railway-managed in production, local Docker for dev)
 - Internet access for Yahoo Finance requests
 
 ## Install
@@ -24,9 +28,25 @@ cd frontend
 npm install
 ```
 
+## Database
+
+The app reads `DATABASE_URL`. For local development, start the bundled Postgres via:
+
+```bash
+docker compose up -d postgres
+export DATABASE_URL=postgresql://xscout:xscout@localhost:5432/xscout
+```
+
+Migrations run automatically the first time the app starts and are idempotent.
+They are serialised across replicas with a Postgres advisory lock.
+
+Existing browsers that have a canvas saved in `localStorage` are migrated
+automatically on first load: each inline list is uploaded to the server,
+then the local copy is reduced to layout-only.
+
 ## Run
 
-Start the Flask API locally:
+Start the Flask API locally (with `DATABASE_URL` exported):
 
 ```bash
 .venv/bin/python -m xscout
@@ -70,8 +90,19 @@ The included `Dockerfile` builds the React frontend and serves it from the same 
 
 ## Tests
 
+The default test suite mocks the database and runs without Postgres:
+
 ```bash
 .venv/bin/python -m unittest discover -s tests
 cd frontend
 npm run build
+```
+
+To exercise the integration tests against a real Postgres, bring up the
+local container and point the suite at it:
+
+```bash
+docker compose up -d postgres
+TEST_DATABASE_URL=postgresql://xscout:xscout@localhost:5432/xscout \
+  .venv/bin/python -m unittest discover -s tests
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+# Local development helper. Boots a Postgres instance with the same
+# credentials documented in the README so `.venv/bin/python -m xscout`
+# and the test suite (`TEST_DATABASE_URL=...`) can connect against it.
+services:
+  postgres:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: xscout
+      POSTGRES_PASSWORD: xscout
+      POSTGRES_DB: xscout
+    ports:
+      - "5432:5432"
+    volumes:
+      - xscout-postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U xscout -d xscout"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  xscout-postgres-data:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,7 +14,16 @@ import {
 } from '@xyflow/react';
 import { fetchWatchlistPerformance } from './api/watchlists';
 import { TickerListNode, type TickerListNodeData } from './components/TickerListNode';
-import { loadCanvas, saveCanvas } from './storage/savedLists';
+import { ListsDrawer } from './components/ListsDrawer';
+import { ListsProvider, useLists } from './lists/ListsContext';
+import {
+  clearLegacyCanvas,
+  loadCanvas,
+  loadLegacyCanvas,
+  saveCanvas,
+  type CanvasNode,
+  type StoredCanvas,
+} from './storage/savedLists';
 
 const DEFAULT_VIEWPORT: Viewport = { x: 0, y: 0, zoom: 1 };
 
@@ -22,19 +31,20 @@ function createNodeId(): string {
   if ('randomUUID' in crypto) {
     return crypto.randomUUID();
   }
-
-  return `ticker-list-${Date.now()}`;
+  return `node-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
-function createTickerNode(position: { x: number; y: number }): Node<TickerListNodeData, 'tickerList'> {
+function createCanvasNode(listId: string, position: { x: number; y: number }): CanvasNode {
   return {
     id: createNodeId(),
     type: 'tickerList',
     position,
     style: { width: 560 },
+    // Display state is hydrated each render from the lists context.
     data: {
-      name: 'New ticker list',
-      tickers: ['AAPL', 'MSFT', 'NVDA'],
+      listId,
+      name: '',
+      tickers: [],
       rows: [],
       errors: [],
       status: 'idle',
@@ -42,12 +52,11 @@ function createTickerNode(position: { x: number; y: number }): Node<TickerListNo
   };
 }
 
-function stripCallbacks(
-  nodes: Array<Node<TickerListNodeData, 'tickerList'>>,
-): Array<Node<TickerListNodeData, 'tickerList'>> {
+function stripCallbacks(nodes: CanvasNode[]): CanvasNode[] {
   return nodes.map((node) => ({
     ...node,
     data: {
+      listId: node.data.listId,
       name: node.data.name,
       tickers: node.data.tickers,
       rows: node.data.rows,
@@ -57,14 +66,13 @@ function stripCallbacks(
   }));
 }
 
-function getInitialCanvas() {
-  const savedCanvas = loadCanvas();
-  if (savedCanvas) {
-    return savedCanvas;
+function getInitialCanvas(): StoredCanvas {
+  const stored = loadCanvas();
+  if (stored) {
+    return stored;
   }
-
   return {
-    nodes: [createTickerNode({ x: 80, y: 80 })],
+    nodes: [],
     edges: [] as Edge[],
     viewport: DEFAULT_VIEWPORT,
   };
@@ -74,131 +82,247 @@ const nodeTypes = {
   tickerList: TickerListNode,
 };
 
-export default function App() {
+function Workspace() {
   const initialCanvas = useMemo(getInitialCanvas, []);
-  const [nodes, setNodes, onNodesChange] = useNodesState(initialCanvas.nodes);
+  const [nodes, setNodes, onNodesChange] = useNodesState<CanvasNode>(initialCanvas.nodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialCanvas.edges);
   const [viewport, setViewport] = useState<Viewport>(initialCanvas.viewport ?? DEFAULT_VIEWPORT);
   const nodesRef = useRef(nodes);
+  const migrationAttempted = useRef(false);
+
+  const {
+    status: listsStatus,
+    lists,
+    listsById,
+    createList,
+    renameList,
+    setTickers,
+  } = useLists();
 
   useEffect(() => {
     nodesRef.current = nodes;
   }, [nodes]);
 
-  const deleteNode = useCallback(
+  // One-time v1 -> v2 migration: if a legacy canvas exists with inline
+  // name/tickers, upload each node as a server list, replace the nodes
+  // with id-only references, and clear the legacy key.
+  useEffect(() => {
+    if (migrationAttempted.current) {
+      return;
+    }
+    if (listsStatus !== 'ready') {
+      return;
+    }
+    migrationAttempted.current = true;
+
+    const legacy = loadLegacyCanvas();
+    if (!legacy) {
+      return;
+    }
+
+    void (async () => {
+      const migratedNodes: CanvasNode[] = [];
+      for (const legacyNode of legacy.nodes) {
+        const name = (legacyNode.data?.name ?? 'Untitled list').toString();
+        const tickers = Array.isArray(legacyNode.data?.tickers)
+          ? (legacyNode.data?.tickers as string[])
+          : [];
+        try {
+          const created = await createList({ name, tickers });
+          migratedNodes.push({
+            id: legacyNode.id ?? createNodeId(),
+            type: 'tickerList',
+            position: legacyNode.position,
+            style: legacyNode.style ?? { width: 560 },
+            data: {
+              listId: created.id,
+              name: created.name,
+              tickers: created.tickers,
+              rows: [],
+              errors: [],
+              status: 'idle',
+            },
+          });
+        } catch (caught) {
+          console.error('Failed to migrate legacy list', name, caught);
+        }
+      }
+      if (migratedNodes.length > 0) {
+        setNodes(migratedNodes);
+        setEdges(legacy.edges ?? []);
+        setViewport(legacy.viewport ?? DEFAULT_VIEWPORT);
+      }
+      clearLegacyCanvas();
+    })();
+  }, [listsStatus, createList, setEdges, setNodes]);
+
+  // Drop canvas nodes whose underlying server list has been deleted, but
+  // only once we've successfully loaded the list catalog (so a network
+  // blip can't wipe the canvas).
+  useEffect(() => {
+    if (listsStatus !== 'ready') {
+      return;
+    }
+    setNodes((current) => {
+      const alive = current.filter((node) => listsById[node.data.listId] !== undefined);
+      return alive.length === current.length ? current : alive;
+    });
+  }, [listsStatus, listsById, setNodes]);
+
+  const removeNodeFromCanvas = useCallback(
     (nodeId: string) => {
-      setNodes((currentNodes) => currentNodes.filter((node) => node.id !== nodeId));
-      setEdges((currentEdges) =>
-        currentEdges.filter((edge) => edge.source !== nodeId && edge.target !== nodeId),
+      setNodes((current) => current.filter((node) => node.id !== nodeId));
+      setEdges((current) =>
+        current.filter((edge) => edge.source !== nodeId && edge.target !== nodeId),
       );
     },
     [setEdges, setNodes],
   );
 
-  const updateNode = useCallback(
-    (nodeId: string, updates: Partial<TickerListNodeData>) => {
-      setNodes((currentNodes) =>
-        currentNodes.map((node) =>
+  const refreshNode = useCallback(
+    async (nodeId: string) => {
+      const target = nodesRef.current.find((node) => node.id === nodeId);
+      const tickers = target ? listsById[target.data.listId]?.tickers ?? [] : [];
+
+      setNodes((current) =>
+        current.map((node) =>
           node.id === nodeId
-            ? {
-                ...node,
-                data: {
-                  ...node.data,
-                  ...updates,
-                },
-              }
+            ? { ...node, data: { ...node.data, errors: [], status: 'loading' } }
             : node,
         ),
       );
-    },
-    [setNodes],
-  );
-
-  const refreshNode = useCallback(
-    async (nodeId: string) => {
-      const tickers = nodesRef.current.find((node) => node.id === nodeId)?.data.tickers ?? [];
-
-      setNodes((currentNodes) =>
-        currentNodes.map((node) => {
-          if (node.id !== nodeId) {
-            return node;
-          }
-
-          return {
-            ...node,
-            data: {
-              ...node.data,
-              errors: [],
-              status: 'loading',
-            },
-          };
-        }),
-      );
 
       if (tickers.length === 0) {
-        updateNode(nodeId, {
-          rows: [],
-          errors: ['Enter at least one ticker to show performance.'],
-          status: 'error',
-        });
+        setNodes((current) =>
+          current.map((node) =>
+            node.id === nodeId
+              ? {
+                  ...node,
+                  data: {
+                    ...node.data,
+                    rows: [],
+                    errors: ['Enter at least one ticker to show performance.'],
+                    status: 'error',
+                  },
+                }
+              : node,
+          ),
+        );
         return;
       }
 
       try {
         const result = await fetchWatchlistPerformance(tickers);
-        updateNode(nodeId, {
-          rows: result.rows,
-          errors: result.errors,
-          status: result.errors.length > 0 ? 'error' : 'ready',
-        });
+        setNodes((current) =>
+          current.map((node) =>
+            node.id === nodeId
+              ? {
+                  ...node,
+                  data: {
+                    ...node.data,
+                    rows: result.rows,
+                    errors: result.errors,
+                    status: result.errors.length > 0 ? 'error' : 'ready',
+                  },
+                }
+              : node,
+          ),
+        );
       } catch (error) {
-        updateNode(nodeId, {
-          rows: [],
-          errors: [error instanceof Error ? error.message : 'Unable to refresh performance.'],
-          status: 'error',
-        });
+        setNodes((current) =>
+          current.map((node) =>
+            node.id === nodeId
+              ? {
+                  ...node,
+                  data: {
+                    ...node.data,
+                    rows: [],
+                    errors: [
+                      error instanceof Error ? error.message : 'Unable to refresh performance.',
+                    ],
+                    status: 'error',
+                  },
+                }
+              : node,
+          ),
+        );
       }
     },
-    [setNodes, updateNode],
+    [listsById, setNodes],
   );
 
-  const addNode = useCallback(() => {
-    setNodes((currentNodes) => [
-      ...currentNodes,
-      createTickerNode({
-        x: 80 + currentNodes.length * 40,
-        y: 80 + currentNodes.length * 40,
-      }),
-    ]);
-  }, [setNodes]);
+  const addListToCanvas = useCallback(
+    (listId: string) => {
+      setNodes((current) => {
+        if (current.some((node) => node.data.listId === listId)) {
+          return current;
+        }
+        // Tile new nodes in a 3-wide grid so consecutive lists don't pile
+        // up on top of each other. Nodes are 560px wide; 600px stride
+        // leaves a small gutter, and 380px row stride matches min height.
+        const index = current.length;
+        const columnsPerRow = 3;
+        return [
+          ...current,
+          createCanvasNode(listId, {
+            x: 80 + (index % columnsPerRow) * 600,
+            y: 80 + Math.floor(index / columnsPerRow) * 380,
+          }),
+        ];
+      });
+    },
+    [setNodes],
+  );
 
   const refreshAll = useCallback(() => {
-    nodes.forEach((node) => {
+    for (const node of nodesRef.current) {
       void refreshNode(node.id);
-    });
-  }, [nodes, refreshNode]);
+    }
+  }, [refreshNode]);
+
+  const handleRename = useCallback(
+    (listId: string, name: string) => {
+      void renameList(listId, name);
+    },
+    [renameList],
+  );
+
+  const handleSetTickers = useCallback(
+    (listId: string, tickers: string[]) => {
+      void setTickers(listId, tickers);
+    },
+    [setTickers],
+  );
 
   const onConnect = useCallback(
-    (connection: Connection) => setEdges((currentEdges) => addEdge(connection, currentEdges)),
+    (connection: Connection) => setEdges((current) => addEdge(connection, current)),
     [setEdges],
   );
 
-  const renderedNodes = useMemo(
+  const renderedNodes = useMemo<Node<TickerListNodeData, 'tickerList'>[]>(
     () =>
-      nodes.map((node) => ({
-        ...node,
-        style: {
-          width: 560,
-          ...node.style,
-        },
-        data: {
-          ...node.data,
-          onDelete: deleteNode,
-          onRefresh: refreshNode,
-          onUpdate: updateNode,
-        },
-      })),
-    [deleteNode, nodes, refreshNode, updateNode],
+      nodes.map((node) => {
+        const list = listsById[node.data.listId];
+        return {
+          ...node,
+          style: {
+            width: 560,
+            ...node.style,
+          },
+          data: {
+            ...node.data,
+            listId: node.data.listId,
+            name: list?.name ?? node.data.name ?? '(Missing list)',
+            tickers: list?.tickers ?? node.data.tickers ?? [],
+            missing: list === undefined,
+            onRemoveFromCanvas: removeNodeFromCanvas,
+            onRefresh: refreshNode,
+            onRename: handleRename,
+            onSetTickers: handleSetTickers,
+          },
+        };
+      }),
+    [handleRename, handleSetTickers, listsById, nodes, refreshNode, removeNodeFromCanvas],
   );
 
   useEffect(() => {
@@ -209,6 +333,13 @@ export default function App() {
     });
   }, [edges, nodes, viewport]);
 
+  const pinnedListIds = useMemo(
+    () => new Set(nodes.map((node) => node.data.listId)),
+    [nodes],
+  );
+
+  const canvasHasContent = nodes.length > 0;
+
   return (
     <main className="app-shell">
       <aside className="toolbar" aria-label="Canvas controls">
@@ -217,31 +348,54 @@ export default function App() {
           <p>Arrange ticker lists on a canvas and refresh each list's performance table.</p>
         </div>
         <div className="toolbar__actions">
-          <button type="button" onClick={addNode}>
-            New List
-          </button>
-          <button type="button" onClick={refreshAll}>
+          <button type="button" onClick={refreshAll} disabled={!canvasHasContent}>
             Refresh All
           </button>
         </div>
       </aside>
 
-      <section className="canvas" aria-label="Ticker list canvas">
-        <ReactFlow
-          nodes={renderedNodes}
-          edges={edges}
-          nodeTypes={nodeTypes}
-          onNodesChange={onNodesChange}
-          onEdgesChange={onEdgesChange}
-          onConnect={onConnect}
-          defaultViewport={viewport}
-          onMoveEnd={(_, nextViewport) => setViewport(nextViewport)}
-        >
-          <Background />
-          <Controls />
-          <MiniMap pannable zoomable />
-        </ReactFlow>
-      </section>
+      <div className="workspace">
+        <ListsDrawer
+          pinnedListIds={pinnedListIds}
+          onAddToCanvas={addListToCanvas}
+          onCreateAndAdd={addListToCanvas}
+        />
+
+        <section className="canvas" aria-label="Ticker list canvas">
+          {!canvasHasContent && lists.length === 0 && listsStatus === 'ready' ? (
+            <div className="canvas__placeholder">
+              Create your first list from the sidebar to get started.
+            </div>
+          ) : null}
+          {!canvasHasContent && lists.length > 0 ? (
+            <div className="canvas__placeholder">
+              Pick a list from the sidebar and click <strong>Add</strong> to pin it here.
+            </div>
+          ) : null}
+          <ReactFlow
+            nodes={renderedNodes}
+            edges={edges}
+            nodeTypes={nodeTypes}
+            onNodesChange={onNodesChange}
+            onEdgesChange={onEdgesChange}
+            onConnect={onConnect}
+            defaultViewport={viewport}
+            onMoveEnd={(_, nextViewport) => setViewport(nextViewport)}
+          >
+            <Background />
+            <Controls />
+            <MiniMap pannable zoomable />
+          </ReactFlow>
+        </section>
+      </div>
     </main>
+  );
+}
+
+export default function App() {
+  return (
+    <ListsProvider>
+      <Workspace />
+    </ListsProvider>
   );
 }

--- a/frontend/src/api/lists.ts
+++ b/frontend/src/api/lists.ts
@@ -1,0 +1,61 @@
+export type TickerList = {
+  id: string;
+  name: string;
+  tickers: string[];
+  createdAt: string;
+  updatedAt: string;
+};
+
+type ListsResponse = { lists: TickerList[] };
+
+async function unwrap<T>(response: Response): Promise<T> {
+  if (response.status === 204) {
+    return undefined as T;
+  }
+  const body = (await response.json().catch(() => ({}))) as { error?: string };
+  if (!response.ok) {
+    const message = typeof body.error === 'string' ? body.error : `Request failed with ${response.status}`;
+    throw new Error(message);
+  }
+  return body as T;
+}
+
+export async function fetchTickerLists(): Promise<TickerList[]> {
+  const response = await fetch('/api/ticker-lists');
+  const data = await unwrap<ListsResponse>(response);
+  return data.lists;
+}
+
+export async function createTickerList(input: {
+  name: string;
+  tickers: string[];
+}): Promise<TickerList> {
+  const response = await fetch('/api/ticker-lists', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  });
+  return unwrap<TickerList>(response);
+}
+
+export async function patchTickerList(
+  id: string,
+  changes: { name?: string; tickers?: string[] },
+): Promise<TickerList> {
+  const response = await fetch(`/api/ticker-lists/${encodeURIComponent(id)}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(changes),
+  });
+  return unwrap<TickerList>(response);
+}
+
+export async function deleteTickerList(id: string): Promise<void> {
+  const response = await fetch(`/api/ticker-lists/${encodeURIComponent(id)}`, {
+    method: 'DELETE',
+  });
+  if (response.status === 204) {
+    return;
+  }
+  await unwrap<unknown>(response);
+}

--- a/frontend/src/components/ListsDrawer.tsx
+++ b/frontend/src/components/ListsDrawer.tsx
@@ -1,0 +1,180 @@
+import { useState } from 'react';
+import { useLists } from '../lists/ListsContext';
+import { parseTickers } from '../storage/savedLists';
+
+type ListsDrawerProps = {
+  pinnedListIds: Set<string>;
+  onAddToCanvas: (listId: string) => void;
+  onCreateAndAdd: (listId: string) => void;
+};
+
+export function ListsDrawer({ pinnedListIds, onAddToCanvas, onCreateAndAdd }: ListsDrawerProps) {
+  const { status, error, lists, createList, removeList, refresh } = useLists();
+  const [open, setOpen] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [newTickers, setNewTickers] = useState('AAPL, MSFT, NVDA');
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  async function submitNewList(event: React.FormEvent) {
+    event.preventDefault();
+    setCreateError(null);
+    const trimmed = newName.trim();
+    if (!trimmed) {
+      setCreateError('Give the list a name.');
+      return;
+    }
+    setBusy(true);
+    try {
+      const created = await createList({
+        name: trimmed,
+        tickers: parseTickers(newTickers),
+      });
+      onCreateAndAdd(created.id);
+      setNewName('');
+      setNewTickers('AAPL, MSFT, NVDA');
+      setCreating(false);
+    } catch (caught) {
+      setCreateError(caught instanceof Error ? caught.message : 'Could not create list.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        className="lists-drawer__toggle"
+        onClick={() => setOpen(true)}
+        aria-label="Show lists library"
+      >
+        Lists ({lists.length})
+      </button>
+    );
+  }
+
+  return (
+    <aside className="lists-drawer" aria-label="Ticker lists library">
+      <header className="lists-drawer__header">
+        <h2>Lists</h2>
+        <button
+          type="button"
+          className="ghost-button"
+          onClick={() => setOpen(false)}
+          aria-label="Hide lists library"
+        >
+          Hide
+        </button>
+      </header>
+
+      {status === 'unavailable' ? (
+        <p className="lists-drawer__notice">
+          Server storage is offline. Set <code>DATABASE_URL</code> on the server to enable lists.
+        </p>
+      ) : null}
+      {status === 'error' && error ? (
+        <div className="errors lists-drawer__notice">
+          {error}{' '}
+          <button type="button" className="ghost-button" onClick={() => void refresh()}>
+            Retry
+          </button>
+        </div>
+      ) : null}
+
+      <ul className="lists-drawer__items">
+        {status === 'loading' && lists.length === 0 ? (
+          <li className="lists-drawer__empty">Loading…</li>
+        ) : null}
+        {status === 'ready' && lists.length === 0 ? (
+          <li className="lists-drawer__empty">No lists yet. Create your first below.</li>
+        ) : null}
+        {lists.map((list) => {
+          const pinned = pinnedListIds.has(list.id);
+          return (
+            <li key={list.id} className="lists-drawer__item">
+              <div className="lists-drawer__item-text">
+                <strong>{list.name}</strong>
+                <span>{list.tickers.length} tickers</span>
+              </div>
+              <div className="lists-drawer__item-actions">
+                <button
+                  type="button"
+                  onClick={() => onAddToCanvas(list.id)}
+                  disabled={pinned}
+                  title={pinned ? 'Already on canvas' : 'Add to canvas'}
+                >
+                  {pinned ? 'On canvas' : 'Add'}
+                </button>
+                <button
+                  type="button"
+                  className="danger-button"
+                  onClick={() => {
+                    if (window.confirm(`Delete "${list.name}"? This cannot be undone.`)) {
+                      void removeList(list.id);
+                    }
+                  }}
+                  aria-label={`Delete ${list.name}`}
+                >
+                  Delete
+                </button>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+
+      <div className="lists-drawer__create">
+        {creating ? (
+          <form onSubmit={submitNewList}>
+            <label className="ticker-node__label">
+              Name
+              <input
+                value={newName}
+                onChange={(event) => setNewName(event.target.value)}
+                placeholder="e.g. Megacaps"
+                aria-label="New list name"
+                autoFocus
+              />
+            </label>
+            <label className="ticker-node__label">
+              Tickers
+              <textarea
+                value={newTickers}
+                onChange={(event) => setNewTickers(event.target.value)}
+                rows={2}
+                aria-label="New list tickers"
+              />
+            </label>
+            {createError ? <div className="errors">{createError}</div> : null}
+            <div className="lists-drawer__create-actions">
+              <button type="submit" disabled={busy}>
+                {busy ? 'Saving…' : 'Create + add'}
+              </button>
+              <button
+                type="button"
+                className="ghost-button"
+                onClick={() => {
+                  setCreating(false);
+                  setCreateError(null);
+                }}
+                disabled={busy}
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setCreating(true)}
+            disabled={status === 'unavailable'}
+          >
+            + New list
+          </button>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/frontend/src/components/TickerListNode.tsx
+++ b/frontend/src/components/TickerListNode.tsx
@@ -1,4 +1,4 @@
-import { memo, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { NodeResizer, type NodeProps } from '@xyflow/react';
 import type { PerformanceRow } from '../api/watchlists';
 import { formatTickers, parseTickers } from '../storage/savedLists';
@@ -6,15 +6,21 @@ import { PerformanceTable } from './PerformanceTable';
 
 export type TickerListStatus = 'idle' | 'loading' | 'ready' | 'error';
 
+// Node `data` carries the layout id plus _derived_ list content (name,
+// tickers) supplied by `App.tsx` from the lists context. The mutating
+// callbacks fire against the lists context, not against per-node state.
 export type TickerListNodeData = {
+  listId: string;
   name: string;
   tickers: string[];
   rows: PerformanceRow[];
   errors: string[];
   status: TickerListStatus;
-  onDelete?: (nodeId: string) => void;
+  missing?: boolean;
+  onRemoveFromCanvas?: (nodeId: string) => void;
   onRefresh?: (nodeId: string) => void;
-  onUpdate?: (nodeId: string, updates: Partial<TickerListNodeData>) => void;
+  onRename?: (listId: string, name: string) => void;
+  onSetTickers?: (listId: string, tickers: string[]) => void;
 } & Record<string, unknown>;
 
 function TickerListNodeComponent({ id, data, selected }: NodeProps) {
@@ -22,14 +28,36 @@ function TickerListNodeComponent({ id, data, selected }: NodeProps) {
   const [name, setName] = useState(nodeData.name);
   const [tickers, setTickers] = useState(formatTickers(nodeData.tickers));
 
-  function saveChanges() {
-    nodeData.onUpdate?.(id, {
-      name: name.trim() || 'Untitled list',
-      tickers: parseTickers(tickers),
-      rows: [],
-      errors: [],
-      status: 'idle',
-    });
+  // Keep local editing state in sync when the underlying list mutates
+  // somewhere else (e.g. renamed in the sidebar, or another tab).
+  useEffect(() => {
+    setName(nodeData.name);
+  }, [nodeData.name]);
+  useEffect(() => {
+    setTickers(formatTickers(nodeData.tickers));
+  }, [nodeData.tickers]);
+
+  function commitName() {
+    const cleaned = name.trim();
+    if (!cleaned) {
+      setName(nodeData.name);
+      return;
+    }
+    if (cleaned === nodeData.name) {
+      return;
+    }
+    nodeData.onRename?.(nodeData.listId, cleaned);
+  }
+
+  function commitTickers() {
+    const parsed = parseTickers(tickers);
+    if (
+      parsed.length === nodeData.tickers.length &&
+      parsed.every((value, index) => value === nodeData.tickers[index])
+    ) {
+      return;
+    }
+    nodeData.onSetTickers?.(nodeData.listId, parsed);
   }
 
   return (
@@ -42,13 +70,14 @@ function TickerListNodeComponent({ id, data, selected }: NodeProps) {
             aria-label="Ticker list name"
             value={name}
             onChange={(event) => setName(event.target.value)}
-            onBlur={saveChanges}
+            onBlur={commitName}
           />
           <button
             className="danger-button icon-button nodrag"
             type="button"
-            aria-label={`Delete ${name.trim() || 'this list'}`}
-            onClick={() => nodeData.onDelete?.(id)}
+            aria-label={`Remove ${nodeData.name || 'this list'} from canvas`}
+            title="Remove from canvas (list stays in your library)"
+            onClick={() => nodeData.onRemoveFromCanvas?.(id)}
           >
             <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
               <path
@@ -61,6 +90,10 @@ function TickerListNodeComponent({ id, data, selected }: NodeProps) {
         <p>{nodeData.tickers.length} tickers</p>
       </header>
 
+      {nodeData.missing ? (
+        <div className="errors">This list is no longer in your library.</div>
+      ) : null}
+
       <label className="ticker-node__label">
         Tickers
         <textarea
@@ -68,8 +101,9 @@ function TickerListNodeComponent({ id, data, selected }: NodeProps) {
           value={tickers}
           rows={2}
           onChange={(event) => setTickers(event.target.value)}
-          onBlur={saveChanges}
+          onBlur={commitTickers}
           aria-label="Ticker symbols"
+          disabled={nodeData.missing}
         />
       </label>
 
@@ -77,7 +111,7 @@ function TickerListNodeComponent({ id, data, selected }: NodeProps) {
         <button
           className="nodrag"
           type="button"
-          disabled={nodeData.status === 'loading'}
+          disabled={nodeData.status === 'loading' || nodeData.missing}
           onClick={() => nodeData.onRefresh?.(id)}
         >
           {nodeData.status === 'loading' ? 'Refreshing...' : 'Refresh'}

--- a/frontend/src/lists/ListsContext.tsx
+++ b/frontend/src/lists/ListsContext.tsx
@@ -1,0 +1,168 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import {
+  createTickerList,
+  deleteTickerList,
+  fetchTickerLists,
+  patchTickerList,
+  type TickerList,
+} from '../api/lists';
+
+export type ListsStatus = 'loading' | 'ready' | 'error' | 'unavailable';
+
+type ListsContextValue = {
+  status: ListsStatus;
+  error: string | null;
+  lists: TickerList[];
+  listsById: Record<string, TickerList>;
+  refresh: () => Promise<void>;
+  createList: (input: { name: string; tickers: string[] }) => Promise<TickerList>;
+  renameList: (id: string, name: string) => Promise<TickerList | null>;
+  setTickers: (id: string, tickers: string[]) => Promise<TickerList | null>;
+  removeList: (id: string) => Promise<void>;
+};
+
+const ListsContext = createContext<ListsContextValue | undefined>(undefined);
+
+export function ListsProvider({ children }: { children: ReactNode }) {
+  const [status, setStatus] = useState<ListsStatus>('loading');
+  const [error, setError] = useState<string | null>(null);
+  const [lists, setLists] = useState<TickerList[]>([]);
+  const fetchedOnce = useRef(false);
+
+  const refresh = useCallback(async () => {
+    setStatus((current) => (current === 'ready' ? current : 'loading'));
+    try {
+      const result = await fetchTickerLists();
+      setLists(result);
+      setStatus('ready');
+      setError(null);
+    } catch (caught) {
+      const message = caught instanceof Error ? caught.message : 'Failed to load lists.';
+      // Differentiate "server has no DB" from other errors so the UI can
+      // surface a calmer message and gracefully degrade.
+      if (message.includes('DATABASE_URL') || message.includes('503')) {
+        setStatus('unavailable');
+      } else {
+        setStatus('error');
+      }
+      setError(message);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (fetchedOnce.current) {
+      return;
+    }
+    fetchedOnce.current = true;
+    void refresh();
+  }, [refresh]);
+
+  const createList = useCallback(
+    async ({ name, tickers }: { name: string; tickers: string[] }) => {
+      const created = await createTickerList({ name, tickers });
+      setLists((current) => [...current, created]);
+      return created;
+    },
+    [],
+  );
+
+  const renameList = useCallback(async (id: string, name: string) => {
+    const previous = lists.find((entry) => entry.id === id);
+    if (!previous || previous.name === name) {
+      return previous ?? null;
+    }
+    // Optimistic update: paint immediately, roll back on failure.
+    setLists((current) =>
+      current.map((entry) => (entry.id === id ? { ...entry, name } : entry)),
+    );
+    try {
+      const updated = await patchTickerList(id, { name });
+      setLists((current) => current.map((entry) => (entry.id === id ? updated : entry)));
+      return updated;
+    } catch (caught) {
+      setLists((current) =>
+        current.map((entry) => (entry.id === id ? previous : entry)),
+      );
+      throw caught;
+    }
+  }, [lists]);
+
+  const setTickers = useCallback(async (id: string, tickers: string[]) => {
+    const previous = lists.find((entry) => entry.id === id);
+    if (!previous) {
+      return null;
+    }
+    if (
+      previous.tickers.length === tickers.length &&
+      previous.tickers.every((value, index) => value === tickers[index])
+    ) {
+      return previous;
+    }
+    setLists((current) =>
+      current.map((entry) => (entry.id === id ? { ...entry, tickers } : entry)),
+    );
+    try {
+      const updated = await patchTickerList(id, { tickers });
+      setLists((current) => current.map((entry) => (entry.id === id ? updated : entry)));
+      return updated;
+    } catch (caught) {
+      setLists((current) =>
+        current.map((entry) => (entry.id === id ? previous : entry)),
+      );
+      throw caught;
+    }
+  }, [lists]);
+
+  const removeList = useCallback(async (id: string) => {
+    const previous = lists;
+    setLists((current) => current.filter((entry) => entry.id !== id));
+    try {
+      await deleteTickerList(id);
+    } catch (caught) {
+      setLists(previous);
+      throw caught;
+    }
+  }, [lists]);
+
+  const listsById = useMemo(() => {
+    const map: Record<string, TickerList> = {};
+    for (const entry of lists) {
+      map[entry.id] = entry;
+    }
+    return map;
+  }, [lists]);
+
+  const value = useMemo<ListsContextValue>(
+    () => ({
+      status,
+      error,
+      lists,
+      listsById,
+      refresh,
+      createList,
+      renameList,
+      setTickers,
+      removeList,
+    }),
+    [status, error, lists, listsById, refresh, createList, renameList, setTickers, removeList],
+  );
+
+  return <ListsContext.Provider value={value}>{children}</ListsContext.Provider>;
+}
+
+export function useLists(): ListsContextValue {
+  const context = useContext(ListsContext);
+  if (context === undefined) {
+    throw new Error('useLists must be used within a ListsProvider.');
+  }
+  return context;
+}

--- a/frontend/src/storage/savedLists.ts
+++ b/frontend/src/storage/savedLists.ts
@@ -1,26 +1,44 @@
 import type { Edge, Node, Viewport } from '@xyflow/react';
 import type { TickerListNodeData } from '../components/TickerListNode';
 
-const STORAGE_KEY = 'xscout.canvas.v1';
+const STORAGE_KEY_V1 = 'xscout.canvas.v1';
+const STORAGE_KEY_V2 = 'xscout.canvas.v2';
+
+// v2 canvas state holds layout only: each node references a server-side
+// ticker list by `listId`. Names and tickers live in Postgres.
+export type CanvasNode = Node<TickerListNodeData, 'tickerList'>;
 
 export type StoredCanvas = {
-  nodes: Array<Node<TickerListNodeData, 'tickerList'>>;
+  nodes: CanvasNode[];
+  edges: Edge[];
+  viewport?: Viewport;
+};
+
+type V1CanvasNode = Node<
+  {
+    name?: string;
+    tickers?: string[];
+    [key: string]: unknown;
+  },
+  'tickerList'
+>;
+
+export type LegacyCanvas = {
+  nodes: V1CanvasNode[];
   edges: Edge[];
   viewport?: Viewport;
 };
 
 export function loadCanvas(): StoredCanvas | null {
   try {
-    const rawCanvas = window.localStorage.getItem(STORAGE_KEY);
-    if (!rawCanvas) {
+    const raw = window.localStorage.getItem(STORAGE_KEY_V2);
+    if (!raw) {
       return null;
     }
-
-    const parsed = JSON.parse(rawCanvas) as StoredCanvas;
+    const parsed = JSON.parse(raw) as StoredCanvas;
     if (!Array.isArray(parsed.nodes) || !Array.isArray(parsed.edges)) {
       return null;
     }
-
     return parsed;
   } catch {
     return null;
@@ -28,7 +46,27 @@ export function loadCanvas(): StoredCanvas | null {
 }
 
 export function saveCanvas(canvas: StoredCanvas): void {
-  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(canvas));
+  window.localStorage.setItem(STORAGE_KEY_V2, JSON.stringify(canvas));
+}
+
+export function loadLegacyCanvas(): LegacyCanvas | null {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY_V1);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw) as LegacyCanvas;
+    if (!Array.isArray(parsed.nodes) || !Array.isArray(parsed.edges)) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function clearLegacyCanvas(): void {
+  window.localStorage.removeItem(STORAGE_KEY_V1);
 }
 
 export function parseTickers(rawTickers: string): string[] {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -85,8 +85,162 @@ textarea {
   gap: 12px;
 }
 
+.workspace {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  min-height: 0;
+  position: relative;
+}
+
+.lists-drawer {
+  width: 320px;
+}
+
 .canvas {
   min-height: 0;
+  position: relative;
+}
+
+.canvas__placeholder {
+  background: rgb(255 255 255 / 75%);
+  border: 1px dashed #cbd2df;
+  border-radius: 12px;
+  color: #5d687c;
+  left: 50%;
+  padding: 14px 20px;
+  pointer-events: none;
+  position: absolute;
+  top: 24px;
+  transform: translateX(-50%);
+  z-index: 4;
+}
+
+.lists-drawer {
+  background: #ffffff;
+  border-right: 1px solid #dfe3ec;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 0;
+  overflow: hidden;
+  padding: 16px;
+}
+
+.lists-drawer__header {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+
+.lists-drawer__header h2 {
+  font-size: 1rem;
+  letter-spacing: 0.04em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.lists-drawer__items {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  gap: 8px;
+  list-style: none;
+  margin: 0;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0;
+}
+
+.lists-drawer__item {
+  align-items: center;
+  background: #f6f7fb;
+  border: 1px solid #e7eaf1;
+  border-radius: 10px;
+  display: grid;
+  gap: 8px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  padding: 10px 12px;
+}
+
+.lists-drawer__item-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.lists-drawer__item-text strong {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.lists-drawer__item-text span {
+  color: #5d687c;
+  font-size: 0.8rem;
+}
+
+.lists-drawer__item-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.lists-drawer__item-actions button {
+  padding: 6px 10px;
+  font-size: 0.85rem;
+}
+
+.lists-drawer__empty {
+  color: #5d687c;
+  padding: 8px 4px;
+}
+
+.lists-drawer__create {
+  border-top: 1px solid #e7eaf1;
+  padding-top: 12px;
+}
+
+.lists-drawer__create form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.lists-drawer__create-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.lists-drawer__notice {
+  background: #fff8e6;
+  border-radius: 8px;
+  color: #6b5a17;
+  font-size: 0.85rem;
+  padding: 8px 12px;
+}
+
+.lists-drawer__toggle {
+  background: #ffffff;
+  border: 1px solid #dfe3ec;
+  border-radius: 999px;
+  color: #172033;
+  font-size: 0.85rem;
+  font-weight: 700;
+  left: 16px;
+  padding: 8px 14px;
+  position: absolute;
+  top: 16px;
+  z-index: 5;
+}
+
+.ghost-button {
+  background: transparent;
+  border: 1px solid transparent;
+  color: #2454ff;
+  padding: 6px 10px;
+}
+
+.ghost-button:hover {
+  background: rgb(36 84 255 / 8%);
 }
 
 .react-flow {
@@ -294,10 +448,37 @@ th {
   }
 
   .toolbar,
-  .ticker-node {
+  .ticker-node,
+  .lists-drawer {
     background: #151b2a;
     border-color: #2b3548;
     color: #eef2f8;
+  }
+
+  .lists-drawer__item {
+    background: #1d2637;
+    border-color: #2b3548;
+  }
+
+  .lists-drawer__item-text span,
+  .lists-drawer__empty {
+    color: #aab4c5;
+  }
+
+  .lists-drawer__toggle,
+  .canvas__placeholder {
+    background: #151b2a;
+    border-color: #2b3548;
+    color: #eef2f8;
+  }
+
+  .lists-drawer__notice {
+    background: #2a2418;
+    color: #f2d97f;
+  }
+
+  .ghost-button {
+    color: #88a4ff;
   }
 
   .react-flow {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 yfinance==1.2.1
 Flask
 gunicorn
+psycopg[binary]>=3.1,<4
+psycopg-pool>=3.2,<4

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -35,9 +35,9 @@ class ComputePerformanceTests(unittest.TestCase):
 class SortSnapshotsTests(unittest.TestCase):
     def test_numeric_sort_keeps_missing_values_last(self) -> None:
         snapshots = [
-            StockSnapshot("AAPL", 180.0, 3_000_000_000_000.0, None, None, None, None, None),
-            StockSnapshot("MSFT", None, 2_500_000_000_000.0, None, None, None, None, None),
-            StockSnapshot("NVDA", 120.0, 2_000_000_000_000.0, None, None, None, None, None),
+            StockSnapshot("AAPL", 180.0, 3_000_000_000_000.0, None, None, None, None, None, None, None, None),
+            StockSnapshot("MSFT", None, 2_500_000_000_000.0, None, None, None, None, None, None, None, None),
+            StockSnapshot("NVDA", 120.0, 2_000_000_000_000.0, None, None, None, None, None, None, None, None),
         ]
 
         ordered = sort_snapshots(snapshots, "price", descending=True)
@@ -78,8 +78,8 @@ class WebAppTests(unittest.TestCase):
 
     def test_api_returns_watchlist_performance_rows(self) -> None:
         snapshots = {
-            "AAPL": StockSnapshot("AAPL", 180.0, 3_000_000_000_000.0, 1.2, 2.3, 3.4, 4.5, 5.6),
-            "MSFT": StockSnapshot("MSFT", 420.0, 2_500_000_000_000.0, -0.5, 1.0, 2.0, 3.0, 4.0),
+            "AAPL": StockSnapshot("AAPL", 180.0, 3_000_000_000_000.0, 1.2, 2.3, 3.4, 4.5, 5.6, 6.7, 7.8, 8.9),
+            "MSFT": StockSnapshot("MSFT", 420.0, 2_500_000_000_000.0, -0.5, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0),
         }
 
         with patch("xscout.market_data.fetch_snapshot", side_effect=lambda ticker: snapshots[ticker]):

--- a/tests/test_ticker_lists_api.py
+++ b/tests/test_ticker_lists_api.py
@@ -1,0 +1,150 @@
+"""Unit tests for the ticker-list API. Mocks the repository layer so these
+tests run without a database."""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import patch
+from uuid import UUID, uuid4
+
+from xscout import app as app_module
+from xscout import ticker_lists
+
+
+def _make_list(name: str = "Tech", tickers: list[str] | None = None) -> ticker_lists.TickerList:
+    return ticker_lists.TickerList(
+        id=uuid4(),
+        name=name,
+        tickers=tickers if tickers is not None else ["AAPL", "MSFT"],
+        created_at=datetime(2026, 5, 12, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 5, 12, tzinfo=timezone.utc),
+    )
+
+
+class TickerListApiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = app_module.app.test_client()
+        configured_patcher = patch.object(app_module.db, "is_configured", return_value=True)
+        configured_patcher.start()
+        self.addCleanup(configured_patcher.stop)
+
+    def test_list_returns_all_records(self) -> None:
+        sample = _make_list()
+        with patch.object(app_module.ticker_lists, "list_all", return_value=[sample]):
+            response = self.client.get("/api/ticker-lists")
+
+        self.assertEqual(response.status_code, 200)
+        body = response.get_json()
+        self.assertEqual(len(body["lists"]), 1)
+        self.assertEqual(body["lists"][0]["id"], str(sample.id))
+        self.assertEqual(body["lists"][0]["tickers"], ["AAPL", "MSFT"])
+
+    def test_create_returns_201_with_created_row(self) -> None:
+        created = _make_list(name="Big Tech", tickers=["AAPL", "GOOGL"])
+        with patch.object(
+            app_module.ticker_lists, "create", return_value=created
+        ) as create_mock:
+            response = self.client.post(
+                "/api/ticker-lists",
+                json={"name": "Big Tech", "tickers": ["aapl", "googl"]},
+            )
+
+        self.assertEqual(response.status_code, 201)
+        create_mock.assert_called_once_with(name="Big Tech", tickers=["aapl", "googl"])
+        self.assertEqual(response.get_json()["name"], "Big Tech")
+
+    def test_create_rejects_empty_name(self) -> None:
+        def boom(**_kwargs: object) -> ticker_lists.TickerList:
+            raise ticker_lists.TickerListValidationError("'name' must not be empty.")
+
+        with patch.object(app_module.ticker_lists, "create", side_effect=boom):
+            response = self.client.post(
+                "/api/ticker-lists",
+                json={"name": "  ", "tickers": ["AAPL"]},
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("name", response.get_json()["error"])
+
+    def test_patch_partial_update(self) -> None:
+        updated = _make_list(name="Renamed")
+        with patch.object(
+            app_module.ticker_lists, "update", return_value=updated
+        ) as update_mock:
+            response = self.client.patch(
+                f"/api/ticker-lists/{updated.id}",
+                json={"name": "Renamed"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        update_mock.assert_called_once_with(str(updated.id), name="Renamed", tickers=None)
+        self.assertEqual(response.get_json()["name"], "Renamed")
+
+    def test_patch_unknown_id_returns_404(self) -> None:
+        def boom(*_args: object, **_kwargs: object) -> ticker_lists.TickerList:
+            raise ticker_lists.TickerListNotFoundError("missing")
+
+        with patch.object(app_module.ticker_lists, "update", side_effect=boom):
+            response = self.client.patch(
+                f"/api/ticker-lists/{uuid4()}",
+                json={"name": "x"},
+            )
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_delete_returns_204(self) -> None:
+        with patch.object(app_module.ticker_lists, "delete") as delete_mock:
+            response = self.client.delete(f"/api/ticker-lists/{uuid4()}")
+
+        self.assertEqual(response.status_code, 204)
+        delete_mock.assert_called_once()
+
+    def test_delete_unknown_id_returns_404(self) -> None:
+        def boom(*_args: object, **_kwargs: object) -> None:
+            raise ticker_lists.TickerListNotFoundError("missing")
+
+        with patch.object(app_module.ticker_lists, "delete", side_effect=boom):
+            response = self.client.delete(f"/api/ticker-lists/{uuid4()}")
+
+        self.assertEqual(response.status_code, 404)
+
+    def test_returns_503_when_database_not_configured(self) -> None:
+        with patch.object(app_module.db, "is_configured", return_value=False):
+            response = self.client.get("/api/ticker-lists")
+
+        self.assertEqual(response.status_code, 503)
+        self.assertIn("DATABASE_URL", response.get_json()["error"])
+
+
+class TickerListValidationTests(unittest.TestCase):
+    """Direct tests for repository-level validation that does not need a DB."""
+
+    def test_validate_tickers_normalises_input(self) -> None:
+        self.assertEqual(
+            ticker_lists._validate_tickers("aapl, msft\nnvda"),
+            ["AAPL", "MSFT", "NVDA"],
+        )
+
+    def test_validate_tickers_rejects_too_many(self) -> None:
+        too_many = [f"T{idx}" for idx in range(ticker_lists.MAX_TICKERS_PER_LIST + 1)]
+        with self.assertRaises(ticker_lists.TickerListValidationError):
+            ticker_lists._validate_tickers(too_many)
+
+    def test_validate_name_strips_and_rejects_empty(self) -> None:
+        self.assertEqual(ticker_lists._validate_name("  Tech  "), "Tech")
+        with self.assertRaises(ticker_lists.TickerListValidationError):
+            ticker_lists._validate_name("   ")
+
+    def test_coerce_uuid_rejects_invalid(self) -> None:
+        with self.assertRaises(ticker_lists.TickerListValidationError):
+            ticker_lists._coerce_uuid("not-a-uuid")
+
+    def test_coerce_uuid_accepts_string_form(self) -> None:
+        value = uuid4()
+        self.assertEqual(ticker_lists._coerce_uuid(str(value)), value)
+        self.assertIsInstance(ticker_lists._coerce_uuid(value), UUID)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ticker_lists_integration.py
+++ b/tests/test_ticker_lists_integration.py
@@ -1,0 +1,91 @@
+"""Integration tests that hit a real Postgres.
+
+Skipped unless ``TEST_DATABASE_URL`` is set. The included
+``docker-compose.yml`` brings up a local Postgres; setting
+
+    export TEST_DATABASE_URL=postgresql://xscout:xscout@localhost:5432/xscout
+
+before running ``.venv/bin/python -m unittest discover -s tests`` is enough
+to exercise these tests locally.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+from xscout import db, ticker_lists
+
+
+_TEST_DATABASE_URL = os.environ.get("TEST_DATABASE_URL")
+
+
+@unittest.skipUnless(
+    _TEST_DATABASE_URL, "TEST_DATABASE_URL is not set; skipping integration tests."
+)
+class TickerListsIntegrationTests(unittest.TestCase):
+    _original_database_url: str | None = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._original_database_url = os.environ.get("DATABASE_URL")
+        os.environ["DATABASE_URL"] = _TEST_DATABASE_URL  # type: ignore[assignment]
+        db.reset_pool_for_testing()
+        db.run_migrations()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        db.close_pool()
+        if cls._original_database_url is None:
+            os.environ.pop("DATABASE_URL", None)
+        else:
+            os.environ["DATABASE_URL"] = cls._original_database_url
+
+    def setUp(self) -> None:
+        with db.get_pool().connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("DELETE FROM ticker_lists")
+                conn.commit()
+
+    def test_create_then_list(self) -> None:
+        created = ticker_lists.create(name="Tech", tickers=["aapl", "MSFT"])
+        self.assertEqual(created.name, "Tech")
+        self.assertEqual(created.tickers, ["AAPL", "MSFT"])
+
+        rows = ticker_lists.list_all()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0].id, created.id)
+
+    def test_update_rename_and_replace_tickers(self) -> None:
+        created = ticker_lists.create(name="Tech", tickers=["AAPL"])
+        renamed = ticker_lists.update(created.id, name="Renamed")
+        self.assertEqual(renamed.name, "Renamed")
+        self.assertEqual(renamed.tickers, ["AAPL"])
+
+        with_new_tickers = ticker_lists.update(created.id, tickers=["GOOGL", "AMZN"])
+        self.assertEqual(with_new_tickers.tickers, ["GOOGL", "AMZN"])
+
+    def test_update_missing_raises(self) -> None:
+        import uuid
+
+        with self.assertRaises(ticker_lists.TickerListNotFoundError):
+            ticker_lists.update(uuid.uuid4(), name="nope")
+
+    def test_delete_removes_row(self) -> None:
+        created = ticker_lists.create(name="Tech", tickers=["AAPL"])
+        ticker_lists.delete(created.id)
+        self.assertEqual(ticker_lists.list_all(), [])
+
+    def test_delete_missing_raises(self) -> None:
+        import uuid
+
+        with self.assertRaises(ticker_lists.TickerListNotFoundError):
+            ticker_lists.delete(uuid.uuid4())
+
+    def test_run_migrations_is_idempotent(self) -> None:
+        # Already migrated in setUpClass; a second call should apply nothing.
+        self.assertEqual(db.run_migrations(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/xscout/app.py
+++ b/xscout/app.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 from typing import Any
 
 import flask
 
+from . import db, ticker_lists
 from .formatting import (
     format_currency,
     format_market_cap,
@@ -22,9 +24,24 @@ from .market_data import (
     sort_snapshots,
 )
 
+LOGGER = logging.getLogger(__name__)
+
 FRONTEND_DIST = Path(__file__).parent / "static" / "app"
 
 app = flask.Flask(__name__, static_folder=str(FRONTEND_DIST), static_url_path="")
+
+
+# Run migrations once at module load, when configured. Skipping in tests
+# (DATABASE_URL unset) keeps the existing unit-test workflow zero-touch.
+# Gunicorn loads this module once in the master process; the advisory lock
+# inside run_migrations() serialises any concurrent attempts from sibling
+# replicas during a deploy.
+if db.is_configured() and os.environ.get("XSCOUT_SKIP_MIGRATIONS") != "1":
+    try:
+        db.init_db()
+    except Exception:  # pragma: no cover - logged for operator visibility
+        LOGGER.exception("Database migrations failed at startup")
+        raise
 
 
 @app.post("/api/watchlists/performance")
@@ -49,6 +66,75 @@ def watchlist_performance() -> flask.Response:
     )
 
 
+@app.get("/api/ticker-lists")
+def list_ticker_lists() -> flask.Response:
+    if not db.is_configured():
+        return _database_unavailable_response()
+    try:
+        lists = ticker_lists.list_all()
+    except Exception:
+        LOGGER.exception("Failed to list ticker lists")
+        return flask.jsonify({"error": "Failed to load ticker lists."}), 500
+    return flask.jsonify({"lists": [item.to_api() for item in lists]})
+
+
+@app.post("/api/ticker-lists")
+def create_ticker_list() -> flask.Response:
+    if not db.is_configured():
+        return _database_unavailable_response()
+    payload = flask.request.get_json(silent=True) or {}
+    try:
+        created = ticker_lists.create(
+            name=payload.get("name"),
+            tickers=payload.get("tickers", []),
+        )
+    except ticker_lists.TickerListValidationError as exc:
+        return flask.jsonify({"error": str(exc)}), 400
+    except Exception:
+        LOGGER.exception("Failed to create ticker list")
+        return flask.jsonify({"error": "Failed to create ticker list."}), 500
+    return flask.jsonify(created.to_api()), 201
+
+
+@app.patch("/api/ticker-lists/<list_id>")
+def update_ticker_list(list_id: str) -> flask.Response:
+    if not db.is_configured():
+        return _database_unavailable_response()
+    payload = flask.request.get_json(silent=True) or {}
+    if not isinstance(payload, dict):
+        return flask.jsonify({"error": "Request body must be a JSON object."}), 400
+    try:
+        updated = ticker_lists.update(
+            list_id,
+            name=payload.get("name") if "name" in payload else None,
+            tickers=payload.get("tickers") if "tickers" in payload else None,
+        )
+    except ticker_lists.TickerListValidationError as exc:
+        return flask.jsonify({"error": str(exc)}), 400
+    except ticker_lists.TickerListNotFoundError:
+        return flask.jsonify({"error": "Ticker list not found."}), 404
+    except Exception:
+        LOGGER.exception("Failed to update ticker list %s", list_id)
+        return flask.jsonify({"error": "Failed to update ticker list."}), 500
+    return flask.jsonify(updated.to_api())
+
+
+@app.delete("/api/ticker-lists/<list_id>")
+def delete_ticker_list(list_id: str) -> flask.Response:
+    if not db.is_configured():
+        return _database_unavailable_response()
+    try:
+        ticker_lists.delete(list_id)
+    except ticker_lists.TickerListValidationError as exc:
+        return flask.jsonify({"error": str(exc)}), 400
+    except ticker_lists.TickerListNotFoundError:
+        return flask.jsonify({"error": "Ticker list not found."}), 404
+    except Exception:
+        LOGGER.exception("Failed to delete ticker list %s", list_id)
+        return flask.jsonify({"error": "Failed to delete ticker list."}), 500
+    return flask.Response(status=204)
+
+
 @app.get("/")
 @app.get("/<path:path>")
 def serve_frontend(path: str = "") -> flask.Response | str:
@@ -68,6 +154,16 @@ def serve_frontend(path: str = "") -> flask.Response | str:
         status=200,
         mimetype="text/plain",
     )
+
+
+def _database_unavailable_response() -> flask.Response:
+    response = flask.jsonify(
+        {
+            "error": "Server storage is not configured. Set DATABASE_URL to a Postgres instance."
+        }
+    )
+    response.status_code = 503
+    return response
 
 
 def _parse_ticker_payload(value: Any) -> list[str]:

--- a/xscout/db.py
+++ b/xscout/db.py
@@ -1,0 +1,230 @@
+"""Database connection, configuration, and migration runner.
+
+Only Postgres is supported. The connection URL is read from the
+``DATABASE_URL`` environment variable (which is how Railway exposes the
+managed Postgres service to the application). For local development, the
+included ``docker-compose.yml`` brings up Postgres on
+``postgresql://xscout:xscout@localhost:5432/xscout``.
+
+Migrations live alongside this module in ``xscout/migrations`` as numbered
+``NNNN_*.sql`` files. They are applied on application startup, serialised
+across Gunicorn workers and replicas with a Postgres advisory lock so two
+processes cannot race on the same upgrade.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Iterable
+
+import psycopg
+from psycopg_pool import ConnectionPool
+
+LOGGER = logging.getLogger(__name__)
+
+# Arbitrary but stable 64-bit integer used as the migration advisory lock key.
+# Two processes calling pg_advisory_lock with the same key block each other,
+# which is exactly what we want so concurrent boots cannot apply migrations
+# in parallel.
+MIGRATION_ADVISORY_LOCK_KEY = 5_472_983_120_557_311
+
+MIGRATIONS_DIR = Path(__file__).parent / "migrations"
+
+_pool: ConnectionPool | None = None
+_pool_lock = threading.Lock()
+
+
+class DatabaseNotConfiguredError(RuntimeError):
+    """Raised when DB access is attempted without a configured DATABASE_URL."""
+
+
+def get_database_url() -> str | None:
+    """Return the configured database URL, normalising legacy ``postgres://``."""
+
+    url = os.environ.get("DATABASE_URL")
+    if not url:
+        return None
+    # SQLAlchemy and psycopg accept the modern ``postgresql://`` form; some
+    # providers (and older Heroku-style configs) still hand out ``postgres://``.
+    if url.startswith("postgres://"):
+        url = "postgresql://" + url[len("postgres://") :]
+    return url
+
+
+def is_configured() -> bool:
+    return get_database_url() is not None
+
+
+def get_pool() -> ConnectionPool:
+    """Return the lazy-initialised process-wide connection pool."""
+
+    global _pool
+    if _pool is not None:
+        return _pool
+
+    with _pool_lock:
+        if _pool is None:
+            url = get_database_url()
+            if url is None:
+                raise DatabaseNotConfiguredError(
+                    "DATABASE_URL is not set; cannot open a Postgres connection."
+                )
+            _pool = ConnectionPool(
+                conninfo=url,
+                min_size=1,
+                max_size=5,
+                kwargs={"autocommit": False},
+                open=True,
+                name="xscout-pool",
+            )
+    return _pool
+
+
+def close_pool() -> None:
+    """Close the connection pool (used by tests for cleanup)."""
+
+    global _pool
+    with _pool_lock:
+        if _pool is not None:
+            _pool.close()
+            _pool = None
+
+
+def connect_with_retry(
+    *,
+    attempts: int = 5,
+    initial_delay_seconds: float = 1.0,
+) -> psycopg.Connection:
+    """Open a single short-lived connection, retrying on transient errors.
+
+    Used for the migration step at startup, which runs before the pool is
+    touched. Railway occasionally attaches DB networking a moment after the
+    web container starts, so a few retries make boots reliable.
+    """
+
+    url = get_database_url()
+    if url is None:
+        raise DatabaseNotConfiguredError(
+            "DATABASE_URL is not set; cannot open a Postgres connection."
+        )
+
+    delay = initial_delay_seconds
+    last_error: Exception | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            return psycopg.connect(url, autocommit=False)
+        except psycopg.OperationalError as exc:
+            last_error = exc
+            LOGGER.warning(
+                "Postgres connect attempt %d/%d failed: %s", attempt, attempts, exc
+            )
+            if attempt == attempts:
+                break
+            time.sleep(delay)
+            delay = min(delay * 2, 16.0)
+
+    assert last_error is not None
+    raise last_error
+
+
+def run_migrations() -> list[int]:
+    """Apply any pending migration files; return the versions actually applied."""
+
+    applied: list[int] = []
+    pending = _discover_migrations()
+
+    with connect_with_retry() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT pg_advisory_lock(%s)", (MIGRATION_ADVISORY_LOCK_KEY,)
+            )
+            try:
+                cur.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS schema_migrations (
+                        version    INTEGER PRIMARY KEY,
+                        applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
+                    )
+                    """
+                )
+                conn.commit()
+
+                cur.execute("SELECT COALESCE(MAX(version), 0) FROM schema_migrations")
+                row = cur.fetchone()
+                current_version = int(row[0]) if row else 0
+
+                for version, path in pending:
+                    if version <= current_version:
+                        continue
+                    LOGGER.info("Applying migration %s", path.name)
+                    sql = path.read_text(encoding="utf-8")
+                    cur.execute(sql)
+                    cur.execute(
+                        "INSERT INTO schema_migrations (version) VALUES (%s)",
+                        (version,),
+                    )
+                    conn.commit()
+                    applied.append(version)
+            except Exception:
+                conn.rollback()
+                raise
+            finally:
+                cur.execute(
+                    "SELECT pg_advisory_unlock(%s)", (MIGRATION_ADVISORY_LOCK_KEY,)
+                )
+                conn.commit()
+
+    return applied
+
+
+def init_db() -> None:
+    """Eagerly run migrations. Safe to call once per process at startup."""
+
+    if not is_configured():
+        LOGGER.warning(
+            "DATABASE_URL is not set; skipping migrations. The ticker-list API will return 503."
+        )
+        return
+    run_migrations()
+
+
+def _discover_migrations() -> list[tuple[int, Path]]:
+    if not MIGRATIONS_DIR.is_dir():
+        return []
+    migrations: list[tuple[int, Path]] = []
+    for path in sorted(MIGRATIONS_DIR.iterdir()):
+        if path.suffix != ".sql":
+            continue
+        version_token = path.stem.split("_", 1)[0]
+        try:
+            version = int(version_token)
+        except ValueError:
+            LOGGER.warning("Skipping migration with non-numeric prefix: %s", path.name)
+            continue
+        migrations.append((version, path))
+    migrations.sort(key=lambda item: item[0])
+    return migrations
+
+
+def reset_pool_for_testing() -> None:
+    """Test-only helper to drop the cached pool so it picks up new env vars."""
+
+    close_pool()
+
+
+__all__: Iterable[str] = (
+    "DatabaseNotConfiguredError",
+    "MIGRATIONS_DIR",
+    "close_pool",
+    "connect_with_retry",
+    "get_database_url",
+    "get_pool",
+    "init_db",
+    "is_configured",
+    "reset_pool_for_testing",
+    "run_migrations",
+)

--- a/xscout/migrations/0001_initial.sql
+++ b/xscout/migrations/0001_initial.sql
@@ -1,0 +1,13 @@
+-- Ticker list catalog. Lists exist independently of any canvas placement;
+-- the React Flow canvas (kept in localStorage) holds only references to
+-- list ids via its node objects.
+CREATE TABLE IF NOT EXISTS ticker_lists (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name       TEXT  NOT NULL,
+    tickers    TEXT[] NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS ticker_lists_updated_at_idx
+    ON ticker_lists (updated_at DESC);

--- a/xscout/ticker_lists.py
+++ b/xscout/ticker_lists.py
@@ -1,0 +1,202 @@
+"""Repository functions for the ``ticker_lists`` table.
+
+The public surface is intentionally small — Flask route handlers call
+into these functions, and tests mock them out at this boundary so route
+tests need not run against a real database.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Sequence
+from uuid import UUID
+
+from .db import get_pool
+from .market_data import parse_tickers as _normalise_tickers
+
+NAME_MAX_LENGTH = 120
+TICKER_MAX_LENGTH = 16
+MAX_TICKERS_PER_LIST = 200
+
+
+class TickerListNotFoundError(LookupError):
+    """Raised when an update/delete targets an id that does not exist."""
+
+
+class TickerListValidationError(ValueError):
+    """Raised when client input fails validation."""
+
+
+@dataclass(frozen=True)
+class TickerList:
+    id: UUID
+    name: str
+    tickers: list[str]
+    created_at: datetime
+    updated_at: datetime
+
+    def to_api(self) -> dict[str, Any]:
+        return {
+            "id": str(self.id),
+            "name": self.name,
+            "tickers": list(self.tickers),
+            "createdAt": self.created_at.isoformat(),
+            "updatedAt": self.updated_at.isoformat(),
+        }
+
+
+def list_all() -> list[TickerList]:
+    with get_pool().connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT id, name, tickers, created_at, updated_at
+                  FROM ticker_lists
+              ORDER BY created_at ASC
+                """
+            )
+            return [_row_to_model(row) for row in cur.fetchall()]
+
+
+def create(*, name: str, tickers: Sequence[str]) -> TickerList:
+    clean_name = _validate_name(name)
+    clean_tickers = _validate_tickers(tickers)
+
+    with get_pool().connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO ticker_lists (name, tickers)
+                     VALUES (%s, %s)
+                  RETURNING id, name, tickers, created_at, updated_at
+                """,
+                (clean_name, clean_tickers),
+            )
+            row = cur.fetchone()
+            conn.commit()
+    assert row is not None
+    return _row_to_model(row)
+
+
+def update(
+    list_id: str | UUID,
+    *,
+    name: str | None = None,
+    tickers: Sequence[str] | None = None,
+) -> TickerList:
+    list_uuid = _coerce_uuid(list_id)
+
+    fields: list[str] = []
+    values: list[Any] = []
+
+    if name is not None:
+        fields.append("name = %s")
+        values.append(_validate_name(name))
+
+    if tickers is not None:
+        fields.append("tickers = %s")
+        values.append(_validate_tickers(tickers))
+
+    if not fields:
+        raise TickerListValidationError(
+            "At least one of 'name' or 'tickers' must be provided."
+        )
+
+    fields.append("updated_at = now()")
+    values.append(list_uuid)
+
+    sql = (
+        "UPDATE ticker_lists SET "
+        + ", ".join(fields)
+        + " WHERE id = %s RETURNING id, name, tickers, created_at, updated_at"
+    )
+
+    with get_pool().connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(sql, values)
+            row = cur.fetchone()
+            if row is None:
+                conn.rollback()
+                raise TickerListNotFoundError(str(list_uuid))
+            conn.commit()
+    return _row_to_model(row)
+
+
+def delete(list_id: str | UUID) -> None:
+    list_uuid = _coerce_uuid(list_id)
+
+    with get_pool().connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute("DELETE FROM ticker_lists WHERE id = %s", (list_uuid,))
+            deleted = cur.rowcount
+            conn.commit()
+    if deleted == 0:
+        raise TickerListNotFoundError(str(list_uuid))
+
+
+def _row_to_model(row: Sequence[Any]) -> TickerList:
+    list_id, name, tickers, created_at, updated_at = row
+    return TickerList(
+        id=list_id if isinstance(list_id, UUID) else UUID(str(list_id)),
+        name=name,
+        tickers=list(tickers or []),
+        created_at=created_at,
+        updated_at=updated_at,
+    )
+
+
+def _coerce_uuid(value: str | UUID) -> UUID:
+    if isinstance(value, UUID):
+        return value
+    try:
+        return UUID(str(value))
+    except ValueError as exc:
+        raise TickerListValidationError(f"Invalid list id: {value!r}") from exc
+
+
+def _validate_name(raw: Any) -> str:
+    if not isinstance(raw, str):
+        raise TickerListValidationError("'name' must be a string.")
+    cleaned = raw.strip()
+    if not cleaned:
+        raise TickerListValidationError("'name' must not be empty.")
+    if len(cleaned) > NAME_MAX_LENGTH:
+        raise TickerListValidationError(
+            f"'name' must be {NAME_MAX_LENGTH} characters or fewer."
+        )
+    return cleaned
+
+
+def _validate_tickers(raw: Any) -> list[str]:
+    if isinstance(raw, str):
+        tickers = _normalise_tickers(raw)
+    elif isinstance(raw, (list, tuple)):
+        joined = " ".join(str(item) for item in raw)
+        tickers = _normalise_tickers(joined)
+    else:
+        raise TickerListValidationError(
+            "'tickers' must be a list of strings or a delimited string."
+        )
+
+    if len(tickers) > MAX_TICKERS_PER_LIST:
+        raise TickerListValidationError(
+            f"A ticker list may contain at most {MAX_TICKERS_PER_LIST} symbols."
+        )
+    for ticker in tickers:
+        if len(ticker) > TICKER_MAX_LENGTH:
+            raise TickerListValidationError(
+                f"Ticker symbol too long: {ticker!r}."
+            )
+    return tickers
+
+
+__all__ = (
+    "TickerList",
+    "TickerListNotFoundError",
+    "TickerListValidationError",
+    "list_all",
+    "create",
+    "update",
+    "delete",
+)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a Postgres backing store for ticker lists per `feature_requests.md`. No accounts yet — a single global catalog backs every visitor, as agreed.

## Walkthrough

[ticker_lists_e2e_walkthrough.mp4](https://cursor.com/agents/bc-ff793c8d-d911-4e16-ac0b-0c8a12475c03/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fticker_lists_e2e_walkthrough.mp4)

Full create / rename / delete / reload / refresh round-trip against gunicorn + local Postgres.

[Three lists tiled across the canvas without overlap](https://cursor.com/agents/bc-ff793c8d-d911-4e16-ac0b-0c8a12475c03/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftiled_nodes.webp)

New canvas nodes tile in a 3-wide grid so they no longer pile on top of each other.

[Performance table after Refresh All](https://cursor.com/agents/bc-ff793c8d-d911-4e16-ac0b-0c8a12475c03/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_refresh.webp)

`Refresh All` hits Yahoo Finance through the unchanged `/api/watchlists/performance` route.

## Design

Discussed beforehand (3 rounds). Final choices:

- **DB scope**: only the ticker list catalog. Canvas layout (positions, edges, viewport) stays in `localStorage` under a new `xscout.canvas.v2` key.
- **Model**: L2 — lists are first-class objects in a library; canvas nodes reference them by id. Removing a node from the canvas keeps the list. Deleting a list (sidebar Delete button) is destructive and drops any canvas references.
- **Engine**: Postgres on Railway. Driver is `psycopg[binary]` with a per-worker `psycopg_pool.ConnectionPool`.
- **Migrations**: stdlib `xscout/db.py` runner, numbered `.sql` files in `xscout/migrations/`, idempotent, guarded by a Postgres advisory lock so multi-replica deploys can't race. Connection retry with exponential backoff for cold-boot scenarios on Railway.
- **API**: `GET /api/ticker-lists`, `POST /api/ticker-lists`, `PATCH /api/ticker-lists/<id>`, `DELETE /api/ticker-lists/<id>`. Server validates name + ticker count + ticker length and returns 400/404/503 with consistent JSON error bodies.
- **Migration of existing users**: on first load with `localStorage` v1 data, App.tsx uploads each inline list to the server, rewrites the local store to v2 (layout-only), and clears v1. Lossless and idempotent.
- **Auth**: deferred — fully open until accounts arrive.

## What changed

**Backend**
- `xscout/db.py`: connection pool, retry-on-startup, advisory-locked migration runner.
- `xscout/migrations/0001_initial.sql`: `ticker_lists` table (uuid PK, name, `tickers TEXT[]`, timestamps) + `updated_at` index.
- `xscout/ticker_lists.py`: thin repository (`list_all`/`create`/`update`/`delete`) with validation.
- `xscout/app.py`: 4 new routes, eager migration on module load when `DATABASE_URL` is set, 503 fallback when it's not.
- `requirements.txt`: `psycopg[binary]`, `psycopg-pool`.

**Frontend**
- `frontend/src/api/lists.ts`: typed REST client.
- `frontend/src/lists/ListsContext.tsx`: React context, optimistic mutations, unavailable/error states.
- `frontend/src/components/ListsDrawer.tsx`: collapsible sidebar library UI.
- `frontend/src/App.tsx`: refactored canvas to dereference lists by id, with v1→v2 migration, auto-drop of canvas nodes whose list was deleted, and 3-wide node tiling.
- `frontend/src/components/TickerListNode.tsx`: derives name/tickers from context, in-node edits call list mutations.
- `frontend/src/storage/savedLists.ts`: v2 (layout-only) storage + legacy v1 loader.
- `frontend/src/styles.css`: drawer + dark-mode coverage.

**Infra & docs**
- `docker-compose.yml` for local Postgres.
- `README.md` and `AGENTS.md` updated with the new `DATABASE_URL` requirement and the `TEST_DATABASE_URL`-gated integration tests.

## Testing

- ✅ `.venv/bin/python -m unittest discover -s tests` — 29 tests, 23 run + 6 integration skipped (no `TEST_DATABASE_URL`).
- ✅ `TEST_DATABASE_URL=postgresql://xscout:xscout@localhost:5432/xscout .venv/bin/python -m unittest discover -s tests` — all 29 pass, including round-trip CRUD and migration idempotency.
- ✅ `cd frontend && npm run build` — clean TypeScript + Vite build.
- ✅ Manual E2E via gunicorn + local Postgres + Chrome: create / rename / delete / drawer toggle / page reload / refresh-all all pass (see walkthrough above and video review).
- ✅ curl round-trip on all four endpoints, including 400 on empty name and 404 on unknown id.

A pre-existing test bug (`StockSnapshot` constructor missing the new 6m/1y/5y fields) was fixed in a separate first commit so the baseline is green.

## Deploy notes

- Set `DATABASE_URL` on the Railway service (or link the Railway Postgres add-on, which sets it automatically). Migrations run on first boot.
- `XSCOUT_SKIP_MIGRATIONS=1` skips the startup migration step if you ever need to deploy without it.
- The `Dockerfile` and `Procfile` did not change — `psycopg` ships with bundled libpq in the binary wheel.

## Known follow-ups (intentionally out of scope)

- Sharing via per-list tokens — schema (no `owner_id`/`share_token` columns yet) is structured so adding them is non-invasive.
- Replacing the native `window.confirm` delete dialog with a custom modal.
- User accounts.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff793c8d-d911-4e16-ac0b-0c8a12475c03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff793c8d-d911-4e16-ac0b-0c8a12475c03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

