### PR TITLE
Fix canvas dot grid rendering

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
-  Background,
-  BackgroundVariant,
   Controls,
   MiniMap,
   ReactFlow,
@@ -383,11 +381,6 @@ function Workspace() {
             defaultViewport={viewport}
             onMoveEnd={(_, nextViewport) => setViewport(nextViewport)}
           >
-            <Background
-              color="var(--canvas-grid-color)"
-              gap={24}
-              variant={BackgroundVariant.Dots}
-            />
             <Controls />
             <MiniMap pannable zoomable />
           </ReactFlow>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
+  Background,
+  BackgroundVariant,
   Controls,
   MiniMap,
   ReactFlow,
@@ -381,6 +383,11 @@ function Workspace() {
             defaultViewport={viewport}
             onMoveEnd={(_, nextViewport) => setViewport(nextViewport)}
           >
+            <Background
+              color="var(--canvas-grid-color)"
+              gap={24}
+              variant={BackgroundVariant.Dots}
+            />
             <Controls />
             <MiniMap pannable zoomable />
           </ReactFlow>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
+  Background,
+  BackgroundVariant,
   Controls,
   MiniMap,
   ReactFlow,
@@ -381,6 +383,7 @@ function Workspace() {
             defaultViewport={viewport}
             onMoveEnd={(_, nextViewport) => setViewport(nextViewport)}
           >
+            <Background gap={24} size={2} variant={BackgroundVariant.Dots} />
             <Controls />
             <MiniMap pannable zoomable />
           </ReactFlow>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -244,7 +244,7 @@ textarea {
 }
 
 .react-flow {
-  background: radial-gradient(circle at 1px 1px, #dfe3ec 1px, transparent 0);
+  background: radial-gradient(circle at 1px 1px, #cbd2df 1px, transparent 0);
   background-size: 24px 24px;
 }
 
@@ -549,7 +549,7 @@ th {
   }
 
   .react-flow {
-    background: radial-gradient(circle at 1px 1px, #2b3548 1px, transparent 0);
+    background: radial-gradient(circle at 1px 1px, #38445a 1px, transparent 0);
     background-size: 24px 24px;
   }
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,4 +1,6 @@
 :root {
+  --canvas-grid-color: #dfe3ec;
+
   color-scheme: light dark;
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   background: #f6f7fb;
@@ -97,8 +99,6 @@ textarea {
 }
 
 .canvas {
-  background-image: radial-gradient(circle at 1px 1px, #c8ced8 1px, transparent 0);
-  background-size: 24px 24px;
   min-height: 0;
   position: relative;
 }
@@ -244,7 +244,6 @@ textarea {
 .ghost-button:hover {
   background: rgb(36 84 255 / 8%);
 }
-
 
 .ticker-node {
   background: #ffffff;
@@ -508,6 +507,8 @@ th {
 
 @media (prefers-color-scheme: dark) {
   :root {
+    --canvas-grid-color: #2b3548;
+
     background: #0f1420;
     color: #eef2f8;
   }
@@ -544,10 +545,6 @@ th {
 
   .ghost-button {
     color: #88a4ff;
-  }
-
-  .canvas {
-    background-image: radial-gradient(circle at 1px 1px, #3b465a 1px, transparent 0);
   }
 
   input,

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -97,7 +97,7 @@ textarea {
 }
 
 .canvas {
-  background-image: radial-gradient(circle at 1px 1px, #aeb8c8 1px, transparent 0);
+  background-image: radial-gradient(circle at 1px 1px, #c8ced8 1px, transparent 0);
   background-size: 24px 24px;
   min-height: 0;
   position: relative;
@@ -547,7 +547,7 @@ th {
   }
 
   .canvas {
-    background-image: radial-gradient(circle at 1px 1px, #4a5a72 1px, transparent 0);
+    background-image: radial-gradient(circle at 1px 1px, #3b465a 1px, transparent 0);
   }
 
   input,

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -97,6 +97,8 @@ textarea {
 }
 
 .canvas {
+  background-image: radial-gradient(circle at 1px 1px, #aeb8c8 1px, transparent 0);
+  background-size: 24px 24px;
   min-height: 0;
   position: relative;
 }
@@ -243,10 +245,6 @@ textarea {
   background: rgb(36 84 255 / 8%);
 }
 
-.react-flow__pane {
-  background: radial-gradient(circle at 1px 1px, #b8c1cf 1px, transparent 0);
-  background-size: 24px 24px;
-}
 
 .ticker-node {
   background: #ffffff;
@@ -548,9 +546,8 @@ th {
     color: #88a4ff;
   }
 
-  .react-flow__pane {
-    background: radial-gradient(circle at 1px 1px, #4a5a72 1px, transparent 0);
-    background-size: 24px 24px;
+  .canvas {
+    background-image: radial-gradient(circle at 1px 1px, #4a5a72 1px, transparent 0);
   }
 
   input,

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,6 +1,4 @@
 :root {
-  --canvas-grid-color: #dfe3ec;
-
   color-scheme: light dark;
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   background: #f6f7fb;
@@ -243,6 +241,11 @@ textarea {
 
 .ghost-button:hover {
   background: rgb(36 84 255 / 8%);
+}
+
+.react-flow {
+  background: radial-gradient(circle at 1px 1px, #dfe3ec 1px, transparent 0);
+  background-size: 24px 24px;
 }
 
 .ticker-node {
@@ -507,8 +510,6 @@ th {
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --canvas-grid-color: #2b3548;
-
     background: #0f1420;
     color: #eef2f8;
   }
@@ -545,6 +546,11 @@ th {
 
   .ghost-button {
     color: #88a4ff;
+  }
+
+  .react-flow {
+    background: radial-gradient(circle at 1px 1px, #2b3548 1px, transparent 0);
+    background-size: 24px 24px;
   }
 
   input,

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -243,8 +243,8 @@ textarea {
   background: rgb(36 84 255 / 8%);
 }
 
-.react-flow {
-  background: radial-gradient(circle at 1px 1px, #cbd2df 1px, transparent 0);
+.react-flow__pane {
+  background: radial-gradient(circle at 1px 1px, #b8c1cf 1px, transparent 0);
   background-size: 24px 24px;
 }
 
@@ -548,8 +548,8 @@ th {
     color: #88a4ff;
   }
 
-  .react-flow {
-    background: radial-gradient(circle at 1px 1px, #38445a 1px, transparent 0);
+  .react-flow__pane {
+    background: radial-gradient(circle at 1px 1px, #4a5a72 1px, transparent 0);
     background-size: 24px 24px;
   }
 

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -97,10 +97,12 @@ textarea {
 }
 
 .canvas {
-  background-image: radial-gradient(circle at 1px 1px, #c8ced8 1px, transparent 0);
-  background-size: 24px 24px;
   min-height: 0;
   position: relative;
+}
+
+.react-flow {
+  --xy-background-pattern-color: #c8ced8;
 }
 
 .canvas__placeholder {
@@ -546,8 +548,8 @@ th {
     color: #88a4ff;
   }
 
-  .canvas {
-    background-image: radial-gradient(circle at 1px 1px, #3b465a 1px, transparent 0);
+  .react-flow {
+    --xy-background-pattern-color: #3b465a;
   }
 
   input,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Removed the static CSS-rendered dot grid from the canvas.
- Restored a single React Flow `Background` dot grid so spacing and dot size scale with canvas zoom/pan.
- Kept the dot color subtle to match the provided low-contrast reference.

### Testing
- `npm run build` passes.
- Manually verified the canvas at 100% browser zoom, then used React Flow zoom controls and panning to confirm there is one grid and it scales with canvas zoom.

### Walkthrough
[zoom_scaling_canvas_dot_grid_demo.mp4](https://cursor.com/agents/bc-426ca048-9b51-4c09-972c-376dfa516762/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fzoom_scaling_canvas_dot_grid_demo.mp4)
[Zoom-scaling single canvas dot grid](https://cursor.com/agents/bc-426ca048-9b51-4c09-972c-376dfa516762/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fzoom_scaling_canvas_dot_grid.png)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-426ca048-9b51-4c09-972c-376dfa516762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-426ca048-9b51-4c09-972c-376dfa516762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

