### PR TITLE
Refresh performance after adding tickers

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -181,9 +181,10 @@ function Workspace() {
   );
 
   const refreshNode = useCallback(
-    async (nodeId: string) => {
+    async (nodeId: string, tickersOverride?: string[]) => {
       const target = nodesRef.current.find((node) => node.id === nodeId);
-      const tickers = target ? listsById[target.data.listId]?.tickers ?? [] : [];
+      const tickers =
+        tickersOverride ?? (target ? listsById[target.data.listId]?.tickers ?? [] : []);
 
       setNodes((current) =>
         current.map((node) =>
@@ -253,26 +254,28 @@ function Workspace() {
   );
 
   const addListToCanvas = useCallback(
-    (listId: string) => {
+    (listId: string, tickers: string[]) => {
+      if (nodesRef.current.some((node) => node.data.listId === listId)) {
+        return;
+      }
+      // Tile new nodes in a 3-wide grid so consecutive lists do not overlap.
+      const index = nodesRef.current.length;
+      const columnsPerRow = 3;
+      const newNode = createCanvasNode(listId, {
+        x: 80 + (index % columnsPerRow) * 600,
+        y: 80 + Math.floor(index / columnsPerRow) * 380,
+      });
+
       setNodes((current) => {
         if (current.some((node) => node.data.listId === listId)) {
           return current;
         }
-        // Tile new nodes in a 3-wide grid so consecutive lists don't pile
-        // up on top of each other. Nodes are 560px wide; 600px stride
-        // leaves a small gutter, and 380px row stride matches min height.
-        const index = current.length;
-        const columnsPerRow = 3;
-        return [
-          ...current,
-          createCanvasNode(listId, {
-            x: 80 + (index % columnsPerRow) * 600,
-            y: 80 + Math.floor(index / columnsPerRow) * 380,
-          }),
-        ];
+        return [...current, newNode];
       });
+
+      void refreshNode(newNode.id, tickers);
     },
-    [setNodes],
+    [refreshNode, setNodes],
   );
 
   const refreshAll = useCallback(() => {
@@ -289,10 +292,34 @@ function Workspace() {
   );
 
   const handleSetTickers = useCallback(
-    (listId: string, tickers: string[]) => {
-      void setTickers(listId, tickers);
+    (nodeId: string, listId: string, tickers: string[]) => {
+      void (async () => {
+        try {
+          const updated = await setTickers(listId, tickers);
+          if (updated) {
+            await refreshNode(nodeId, updated.tickers);
+          }
+        } catch (error) {
+          setNodes((current) =>
+            current.map((node) =>
+              node.id === nodeId
+                ? {
+                    ...node,
+                    data: {
+                      ...node.data,
+                      errors: [
+                        error instanceof Error ? error.message : 'Unable to update tickers.',
+                      ],
+                      status: 'error',
+                    },
+                  }
+                : node,
+            ),
+          );
+        }
+      })();
     },
-    [setTickers],
+    [refreshNode, setNodes, setTickers],
   );
 
   const onConnect = useCallback(

--- a/frontend/src/components/ListsDrawer.tsx
+++ b/frontend/src/components/ListsDrawer.tsx
@@ -4,8 +4,8 @@ import { parseTickers } from '../storage/savedLists';
 
 type ListsDrawerProps = {
   pinnedListIds: Set<string>;
-  onAddToCanvas: (listId: string) => void;
-  onCreateAndAdd: (listId: string) => void;
+  onAddToCanvas: (listId: string, tickers: string[]) => void;
+  onCreateAndAdd: (listId: string, tickers: string[]) => void;
 };
 
 export function ListsDrawer({ pinnedListIds, onAddToCanvas, onCreateAndAdd }: ListsDrawerProps) {
@@ -31,7 +31,7 @@ export function ListsDrawer({ pinnedListIds, onAddToCanvas, onCreateAndAdd }: Li
         name: trimmed,
         tickers: parseTickers(newTickers),
       });
-      onCreateAndAdd(created.id);
+      onCreateAndAdd(created.id, created.tickers);
       setNewName('');
       setNewTickers('AAPL, MSFT, NVDA');
       setCreating(false);
@@ -101,7 +101,7 @@ export function ListsDrawer({ pinnedListIds, onAddToCanvas, onCreateAndAdd }: Li
               <div className="lists-drawer__item-actions">
                 <button
                   type="button"
-                  onClick={() => onAddToCanvas(list.id)}
+                  onClick={() => onAddToCanvas(list.id, list.tickers)}
                   disabled={pinned}
                   title={pinned ? 'Already on canvas' : 'Add to canvas'}
                 >

--- a/frontend/src/components/PerformanceTable.tsx
+++ b/frontend/src/components/PerformanceTable.tsx
@@ -41,7 +41,7 @@ export function PerformanceTable({ rows, onAddTicker }: PerformanceTableProps) {
     rows.length === 0 ? (
       <tr>
         <td colSpan={COLUMN_COUNT} className="performance-table__empty-hint">
-          No performance loaded yet. Add tickers here, then use refresh in the header.
+          No performance loaded yet. Add tickers here to load performance.
         </td>
       </tr>
     ) : null;

--- a/frontend/src/components/TickerListNode.tsx
+++ b/frontend/src/components/TickerListNode.tsx
@@ -20,7 +20,7 @@ export type TickerListNodeData = {
   onRemoveFromCanvas?: (nodeId: string) => void;
   onRefresh?: (nodeId: string) => void;
   onRename?: (listId: string, name: string) => void;
-  onSetTickers?: (listId: string, tickers: string[]) => void;
+  onSetTickers?: (nodeId: string, listId: string, tickers: string[]) => void;
 } & Record<string, unknown>;
 
 function TickerListNodeComponent({ id, data, selected }: NodeProps) {
@@ -59,7 +59,7 @@ function TickerListNodeComponent({ id, data, selected }: NodeProps) {
     if (!changed) {
       return;
     }
-    nodeData.onSetTickers?.(nodeData.listId, merged);
+    nodeData.onSetTickers?.(id, nodeData.listId, merged);
   }
 
   return (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Refresh performance data immediately when a saved list is added to the canvas.
- Refresh performance data after adding tickers within a list node.
- Update the empty-table hint to describe the new add behavior.

## Testing
- `npm run build`
- `.venv/bin/python -m unittest discover -s tests`
- Manual browser walkthrough against local Postgres/Flask/Vite; verified drawer Add and table Add both load performance rows without using refresh.

## Walkthrough
[add_refresh_performance_demo.mp4](https://cursor.com/agents/bc-fcf013a3-6275-4daf-b215-654df006f0ef/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadd_refresh_performance_demo.mp4)
[Final table showing refreshed AAPL and MSFT rows](https://cursor.com/agents/bc-fcf013a3-6275-4daf-b215-654df006f0ef/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadd_refresh_performance_final.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fcf013a3-6275-4daf-b215-654df006f0ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fcf013a3-6275-4daf-b215-654df006f0ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

