### PR TITLE
Fix responsive canvas restoration and grid alignment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ frontend/node_modules/
 .pytest_cache/
 .mypy_cache/
 .ruff_cache/
+frontend/playwright-report/
+frontend/test-results/
 
 # Build artifacts
 build/

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "react-dom": "latest"
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.1",
         "@types/react": "latest",
         "@types/react-dom": "latest",
         "@vitejs/plugin-react": "latest",
@@ -81,6 +82,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -944,6 +961,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite --host 0.0.0.0",
     "build": "tsc -b && vite build",
     "preview": "vite preview --host 0.0.0.0",
+    "test:canvas": "playwright test",
     "test:viewport": "playwright test tests/viewport-persistence.spec.ts"
   },
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite --host 0.0.0.0",
     "build": "tsc -b && vite build",
-    "preview": "vite preview --host 0.0.0.0"
+    "preview": "vite preview --host 0.0.0.0",
+    "test:viewport": "playwright test tests/viewport-persistence.spec.ts"
   },
   "dependencies": {
     "@xyflow/react": "latest",
@@ -14,6 +15,7 @@
     "react-dom": "latest"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@types/react": "latest",
     "@types/react-dom": "latest",
     "@vitejs/plugin-react": "latest",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: false,
+  workers: 1,
+  reporter: 'line',
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    launchOptions: process.env.CHROME_PATH
+      ? { executablePath: process.env.CHROME_PATH }
+      : undefined,
+  },
+  webServer: {
+    command: 'npm run dev -- --host 127.0.0.1 --port 4173',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: true,
+  },
+});

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -40,8 +40,12 @@ import {
   loadLegacyCanvas,
   parseTickers,
   saveCanvas,
+  storedViewportToViewport,
+  viewportToStoredViewport,
   type CanvasNode,
-  type StoredCanvas,
+  type CanvasSize,
+  type LoadedCanvas,
+  type StoredViewport,
 } from './storage/savedLists';
 
 const DEFAULT_VIEWPORT: Viewport = { x: 0, y: 0, zoom: 1 };
@@ -104,12 +108,17 @@ function serializeNodes(nodes: CanvasNode[]): CanvasNode[] {
   }));
 }
 
-function getInitialCanvas(): StoredCanvas {
+function getInitialCanvas(): LoadedCanvas {
   const stored = loadCanvas();
   if (stored) {
     return { ...stored, nodes: stored.nodes.map(withDefaultSize) };
   }
-  return { nodes: [], edges: [] as Edge[], viewport: undefined };
+  return {
+    nodes: [],
+    edges: [] as Edge[],
+    viewport: undefined,
+    rawViewport: undefined,
+  };
 }
 
 /** Cheap structural comparison so cached node data can keep its identity. */
@@ -149,12 +158,14 @@ function Workspace() {
     zoomOut,
     zoomTo,
     fitView,
+    setViewport,
   } = useReactFlow();
 
   const canvasRef = useRef<HTMLDivElement | null>(null);
   const nodesRef = useRef(nodes);
   const listsApiRef = useRef(listsApi);
-  const viewportRef = useRef<Viewport>(initialCanvas.viewport ?? DEFAULT_VIEWPORT);
+  const viewportRef = useRef<Viewport>(initialCanvas.rawViewport ?? DEFAULT_VIEWPORT);
+  const storedViewportRef = useRef<StoredViewport | undefined>(initialCanvas.viewport);
   const migrationAttempted = useRef(false);
 
   useEffect(() => {
@@ -170,6 +181,27 @@ function Workspace() {
   const persistRef = useRef({ nodes, edges });
   const saveTimer = useRef<number | null>(null);
 
+  const getCanvasSize = useCallback((): CanvasSize | null => {
+    const rect = canvasRef.current?.getBoundingClientRect();
+    if (!rect || rect.width <= 0 || rect.height <= 0) {
+      return null;
+    }
+    return { width: rect.width, height: rect.height };
+  }, []);
+
+  const captureViewport = useCallback(
+    (viewport: Viewport): StoredViewport | undefined => {
+      const canvas = getCanvasSize();
+      if (!canvas) {
+        return storedViewportRef.current;
+      }
+      const stored = viewportToStoredViewport(viewport, canvas);
+      storedViewportRef.current = stored;
+      return stored;
+    },
+    [getCanvasSize],
+  );
+
   const flushSave = useCallback(() => {
     if (saveTimer.current !== null) {
       window.clearTimeout(saveTimer.current);
@@ -178,9 +210,9 @@ function Workspace() {
     saveCanvas({
       nodes: serializeNodes(persistRef.current.nodes),
       edges: persistRef.current.edges,
-      viewport: viewportRef.current,
+      viewport: storedViewportRef.current ?? captureViewport(viewportRef.current),
     });
-  }, []);
+  }, [captureViewport]);
 
   // Dragging, resizing and panning all fire a stream of changes; writing the
   // whole canvas to localStorage on each one stalls the interaction.
@@ -418,7 +450,7 @@ function Workspace() {
 
   // -------------------------------------------------------------- housekeeping
 
-  // One-time v1 -> v2 migration: if a legacy canvas exists with inline
+  // One-time v1 -> v3 migration: if a legacy canvas exists with inline
   // name/tickers, upload each node as a server list, replace the nodes
   // with id-only references, and clear the legacy key.
   useEffect(() => {
@@ -460,12 +492,24 @@ function Workspace() {
         }
       }
       if (migratedNodes.length > 0) {
+        const migratedEdges = legacy.edges ?? [];
+        if (legacy.viewport) {
+          viewportRef.current = legacy.viewport;
+          captureViewport(legacy.viewport);
+          void setViewport(legacy.viewport, { duration: 0 });
+        }
+        persistRef.current = { nodes: migratedNodes, edges: migratedEdges };
+        saveCanvas({
+          nodes: serializeNodes(migratedNodes),
+          edges: migratedEdges,
+          viewport: storedViewportRef.current,
+        });
         setNodes(migratedNodes);
-        setEdges(legacy.edges ?? []);
+        setEdges(migratedEdges);
       }
       clearLegacyCanvas();
     })();
-  }, [listsStatus, setEdges, setNodes]);
+  }, [captureViewport, listsStatus, setEdges, setNodes, setViewport]);
 
   // Drop canvas nodes whose underlying server list has been deleted, but
   // only once we've successfully loaded the list catalog (so a network
@@ -547,10 +591,22 @@ function Workspace() {
     (_event: unknown, nextViewport: Viewport) => {
       canvasRef.current?.classList.remove('is-moving');
       viewportRef.current = nextViewport;
+      captureViewport(nextViewport);
       scheduleSave();
     },
-    [scheduleSave],
+    [captureViewport, scheduleSave],
   );
+
+  const handleFlowInit = useCallback(() => {
+    const canvas = getCanvasSize();
+    if (initialCanvas.viewport && canvas) {
+      const restored = storedViewportToViewport(initialCanvas.viewport, canvas);
+      viewportRef.current = restored;
+      void setViewport(restored, { duration: 0 });
+      return;
+    }
+    captureViewport(viewportRef.current);
+  }, [captureViewport, getCanvasSize, initialCanvas.viewport, setViewport]);
 
   const handleDragOver = useCallback((event: React.DragEvent) => {
     if (!event.dataTransfer.types.includes(LIST_DRAG_MIME)) {
@@ -677,12 +733,17 @@ function Workspace() {
               onNodesChange={onNodesChange}
               onEdgesChange={onEdgesChange}
               onConnect={onConnect}
+              onInit={handleFlowInit}
               onMoveStart={handleMoveStart}
               onMoveEnd={handleMoveEnd}
               onNodeDragStart={handleNodeDragStart}
               onNodeDragStop={handleNodeDragStop}
-              defaultViewport={initialCanvas.viewport ?? DEFAULT_VIEWPORT}
-              fitView={initialCanvas.viewport === undefined && initialCanvas.nodes.length > 0}
+              defaultViewport={initialCanvas.rawViewport ?? DEFAULT_VIEWPORT}
+              fitView={
+                initialCanvas.viewport === undefined &&
+                initialCanvas.rawViewport === undefined &&
+                initialCanvas.nodes.length > 0
+              }
               fitViewOptions={{ padding: 0.15 }}
               colorMode={resolvedTheme}
               minZoom={MIN_ZOOM}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,8 @@ import {
 import { fetchWatchlistPerformance, type PerformanceRow } from './api/watchlists';
 import { NodeActionsProvider, type NodeActions } from './canvas/NodeActionsContext';
 import {
+  CANVAS_GRID_SIZE,
+  CANVAS_SNAP_GRID,
   DEFAULT_NODE_WIDTH,
   ESTIMATED_NODE_HEIGHT,
   LIST_DRAG_MIME,
@@ -748,6 +750,8 @@ function Workspace() {
               colorMode={resolvedTheme}
               minZoom={MIN_ZOOM}
               maxZoom={MAX_ZOOM}
+              snapToGrid
+              snapGrid={CANVAS_SNAP_GRID}
               zoomOnScroll={scrollMode === 'zoom'}
               panOnScroll={scrollMode === 'pan'}
               panOnScrollSpeed={0.75}
@@ -761,7 +765,7 @@ function Workspace() {
               proOptions={{ hideAttribution: false }}
               attributionPosition="bottom-right"
             >
-              <Background gap={22} size={1.6} variant={BackgroundVariant.Dots} />
+              <Background gap={CANVAS_GRID_SIZE} size={1.6} variant={BackgroundVariant.Dots} />
               <CanvasControls canFitView={canvasHasContent} />
               <OffscreenNotice />
               {showMinimap && canvasHasContent ? (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -97,7 +97,11 @@ function serializeNodes(nodes: CanvasNode[]): CanvasNode[] {
     id: node.id,
     type: node.type,
     position: node.position,
-    style: node.style,
+    style: {
+      ...node.style,
+      width: node.width ?? node.style?.width,
+      height: node.height ?? node.style?.height,
+    },
     data: {
       listId: node.data.listId,
       name: node.data.name,

--- a/frontend/src/canvas/constants.ts
+++ b/frontend/src/canvas/constants.ts
@@ -4,6 +4,13 @@ export const MAX_ZOOM = 2.5;
 /** Duration for programmatic viewport tweens (zoom buttons, fit view). */
 export const VIEWPORT_TWEEN_MS = 180;
 
+/** Distance between the visible canvas dots, in flow-space units. */
+export const CANVAS_GRID_SIZE = 22;
+
+/** Cards move and resize in half-dot increments for finer alignment. */
+export const CANVAS_SNAP_SIZE = CANVAS_GRID_SIZE / 2;
+export const CANVAS_SNAP_GRID: [number, number] = [CANVAS_SNAP_SIZE, CANVAS_SNAP_SIZE];
+
 /** Wide enough that every performance column fits without horizontal scrolling. */
 export const DEFAULT_NODE_WIDTH = 840;
 export const MIN_NODE_WIDTH = 320;

--- a/frontend/src/storage/savedLists.ts
+++ b/frontend/src/storage/savedLists.ts
@@ -1,17 +1,38 @@
-import type { Edge, Node, Viewport } from '@xyflow/react';
+import type { Edge, Node, Viewport, XYPosition } from '@xyflow/react';
 import type { TickerListNodeData } from '../components/TickerListNode';
 
 const STORAGE_KEY_V1 = 'xscout.canvas.v1';
 const STORAGE_KEY_V2 = 'xscout.canvas.v2';
+const STORAGE_KEY_V3 = 'xscout.canvas.v3';
 
-// v2 canvas state holds layout only: each node references a server-side
-// ticker list by `listId`. Names and tickers live in Postgres.
+// Canvas state holds layout only: each node references a server-side ticker
+// list by `listId`. Names and tickers live in Postgres.
 export type CanvasNode = Node<TickerListNodeData, 'tickerList'>;
+
+export type CanvasSize = {
+  width: number;
+  height: number;
+};
+
+/**
+ * A React Flow transform is anchored to the canvas's top-left pixel. Persisting
+ * the flow-space point at the canvas center makes the same view portable to a
+ * canvas with different pixel dimensions.
+ */
+export type StoredViewport = {
+  center: XYPosition;
+  zoom: number;
+};
 
 export type StoredCanvas = {
   nodes: CanvasNode[];
   edges: Edge[];
-  viewport?: Viewport;
+  viewport?: StoredViewport;
+};
+
+export type LoadedCanvas = StoredCanvas & {
+  /** Raw v2 transform retained only long enough to migrate it to v3. */
+  rawViewport?: Viewport;
 };
 
 type V1CanvasNode = Node<
@@ -29,40 +50,124 @@ export type LegacyCanvas = {
   viewport?: Viewport;
 };
 
-export function loadCanvas(): StoredCanvas | null {
+type V2Canvas = {
+  nodes: CanvasNode[];
+  edges: Edge[];
+  viewport?: Viewport;
+};
+
+function readCanvas(key: string): unknown {
   try {
-    const raw = window.localStorage.getItem(STORAGE_KEY_V2);
+    const raw = window.localStorage.getItem(key);
     if (!raw) {
       return null;
     }
-    const parsed = JSON.parse(raw) as StoredCanvas;
-    if (!Array.isArray(parsed.nodes) || !Array.isArray(parsed.edges)) {
-      return null;
-    }
-    return parsed;
+    return JSON.parse(raw) as unknown;
   } catch {
     return null;
   }
+}
+
+function isCanvasShape(value: unknown): value is { nodes: CanvasNode[]; edges: Edge[] } {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate = value as { nodes?: unknown; edges?: unknown };
+  return Array.isArray(candidate.nodes) && Array.isArray(candidate.edges);
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isViewport(value: unknown): value is Viewport {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate = value as Partial<Viewport>;
+  return (
+    isFiniteNumber(candidate.x) &&
+    isFiniteNumber(candidate.y) &&
+    isFiniteNumber(candidate.zoom) &&
+    (candidate.zoom ?? 0) > 0
+  );
+}
+
+function isStoredViewport(value: unknown): value is StoredViewport {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate = value as {
+    center?: Partial<XYPosition>;
+    zoom?: number;
+  };
+  return (
+    typeof candidate.center === 'object' &&
+    candidate.center !== null &&
+    isFiniteNumber(candidate.center.x) &&
+    isFiniteNumber(candidate.center.y) &&
+    isFiniteNumber(candidate.zoom) &&
+    (candidate.zoom ?? 0) > 0
+  );
+}
+
+export function viewportToStoredViewport(
+  viewport: Viewport,
+  canvas: CanvasSize,
+): StoredViewport {
+  return {
+    center: {
+      x: (canvas.width / 2 - viewport.x) / viewport.zoom,
+      y: (canvas.height / 2 - viewport.y) / viewport.zoom,
+    },
+    zoom: viewport.zoom,
+  };
+}
+
+export function storedViewportToViewport(
+  viewport: StoredViewport,
+  canvas: CanvasSize,
+): Viewport {
+  return {
+    x: canvas.width / 2 - viewport.center.x * viewport.zoom,
+    y: canvas.height / 2 - viewport.center.y * viewport.zoom,
+    zoom: viewport.zoom,
+  };
+}
+
+export function loadCanvas(): LoadedCanvas | null {
+  const v3 = readCanvas(STORAGE_KEY_V3);
+  if (isCanvasShape(v3)) {
+    const candidate = v3 as StoredCanvas;
+    return {
+      nodes: candidate.nodes,
+      edges: candidate.edges,
+      viewport: isStoredViewport(candidate.viewport) ? candidate.viewport : undefined,
+    };
+  }
+
+  const v2 = readCanvas(STORAGE_KEY_V2);
+  if (!isCanvasShape(v2)) {
+    return null;
+  }
+  const candidate = v2 as V2Canvas;
+  return {
+    nodes: candidate.nodes,
+    edges: candidate.edges,
+    rawViewport: isViewport(candidate.viewport) ? candidate.viewport : undefined,
+  };
 }
 
 export function saveCanvas(canvas: StoredCanvas): void {
-  window.localStorage.setItem(STORAGE_KEY_V2, JSON.stringify(canvas));
+  window.localStorage.setItem(STORAGE_KEY_V3, JSON.stringify(canvas));
 }
 
 export function loadLegacyCanvas(): LegacyCanvas | null {
-  try {
-    const raw = window.localStorage.getItem(STORAGE_KEY_V1);
-    if (!raw) {
-      return null;
-    }
-    const parsed = JSON.parse(raw) as LegacyCanvas;
-    if (!Array.isArray(parsed.nodes) || !Array.isArray(parsed.edges)) {
-      return null;
-    }
-    return parsed;
-  } catch {
+  const parsed = readCanvas(STORAGE_KEY_V1);
+  if (!isCanvasShape(parsed)) {
     return null;
   }
+  return parsed as LegacyCanvas;
 }
 
 export function clearLegacyCanvas(): void {

--- a/frontend/tests/grid-snapping.spec.ts
+++ b/frontend/tests/grid-snapping.spec.ts
@@ -1,0 +1,144 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const CANVAS_KEY = 'xscout.canvas.v3';
+const SNAP_SIZE = 11;
+
+type StoredNodeLayout = {
+  position: { x: number; y: number };
+  style: { width: number; height: number };
+};
+
+async function mockApi(page: Page) {
+  await page.route('**/api/ticker-lists', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        lists: [
+          {
+            id: 'grid-list',
+            name: 'Grid alignment',
+            tickers: ['AAPL'],
+            createdAt: '2026-01-01T00:00:00Z',
+            updatedAt: '2026-01-01T00:00:00Z',
+          },
+        ],
+      }),
+    }),
+  );
+  await page.route('**/api/watchlists/performance', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ rows: [], errors: [] }),
+    }),
+  );
+}
+
+async function storedNode(page: Page): Promise<StoredNodeLayout> {
+  return page.evaluate((key) => {
+    const canvas = JSON.parse(window.localStorage.getItem(key) ?? '{"nodes":[]}');
+    const node = canvas.nodes[0];
+    return {
+      position: node.position,
+      style: {
+        width: Number(node.style.width),
+        height: Number(node.style.height),
+      },
+    };
+  }, CANVAS_KEY);
+}
+
+function expectOnGrid(value: number) {
+  expect(value).toBeCloseTo(Math.round(value / SNAP_SIZE) * SNAP_SIZE, 5);
+}
+
+test('dragging and resizing use half-grid increments', async ({ page }) => {
+  await mockApi(page);
+  await page.addInitScript(
+    ({ canvasKey, canvas }) => {
+      window.localStorage.clear();
+      window.localStorage.setItem(canvasKey, JSON.stringify(canvas));
+      window.localStorage.setItem(
+        'xscout.prefs.v1',
+        JSON.stringify({
+          theme: 'light',
+          scrollMode: 'zoom',
+          drawerOpen: false,
+          drawerWidth: 304,
+          showMinimap: false,
+        }),
+      );
+    },
+    {
+      canvasKey: CANVAS_KEY,
+      canvas: {
+        nodes: [
+          {
+            id: 'grid-node',
+            type: 'tickerList',
+            position: { x: 220, y: 132 },
+            style: { width: 440, height: 330 },
+            data: {
+              listId: 'grid-list',
+              name: 'Grid alignment',
+              tickers: ['AAPL'],
+              rows: [],
+              errors: [],
+              status: 'idle',
+            },
+          },
+        ],
+        edges: [],
+        viewport: { center: { x: 640, y: 373 }, zoom: 1 },
+      },
+    },
+  );
+
+  await page.goto('/');
+  const node = page.locator('[data-id="grid-node"]');
+  await expect(node).toBeVisible();
+  await page.waitForTimeout(450);
+
+  const beforeDrag = await storedNode(page);
+  const dragBox = await node.boundingBox();
+  if (!dragBox) {
+    throw new Error('Grid node has no bounding box');
+  }
+  const dragStart = { x: dragBox.x + 24, y: dragBox.y + 55 };
+  await page.mouse.move(dragStart.x, dragStart.y);
+  await page.mouse.down();
+  await page.mouse.move(dragStart.x + 37, dragStart.y + 25, { steps: 8 });
+  await page.mouse.up();
+  await page.waitForTimeout(550);
+
+  const afterDrag = await storedNode(page);
+  expect(afterDrag.position).not.toEqual(beforeDrag.position);
+  expectOnGrid(afterDrag.position.x);
+  expectOnGrid(afterDrag.position.y);
+  expectOnGrid(afterDrag.position.x - beforeDrag.position.x);
+  expectOnGrid(afterDrag.position.y - beforeDrag.position.y);
+
+  const beforeResize = afterDrag;
+  const resizeBox = await node.boundingBox();
+  if (!resizeBox) {
+    throw new Error('Grid node has no bounding box after dragging');
+  }
+  const resizeStart = {
+    x: resizeBox.x + resizeBox.width,
+    y: resizeBox.y + resizeBox.height,
+  };
+  await page.mouse.move(resizeStart.x, resizeStart.y);
+  await page.mouse.down();
+  await page.mouse.move(resizeStart.x + 37, resizeStart.y + 25, { steps: 8 });
+  await page.mouse.up();
+  await page.waitForTimeout(550);
+
+  const afterResize = await storedNode(page);
+  expect(afterResize.style.width).toBeGreaterThan(beforeResize.style.width);
+  expect(afterResize.style.height).toBeGreaterThan(beforeResize.style.height);
+  expectOnGrid(afterResize.style.width);
+  expectOnGrid(afterResize.style.height);
+  expectOnGrid(afterResize.style.width - beforeResize.style.width);
+  expectOnGrid(afterResize.style.height - beforeResize.style.height);
+});

--- a/frontend/tests/grid-snapping.spec.ts
+++ b/frontend/tests/grid-snapping.spec.ts
@@ -53,10 +53,13 @@ function expectOnGrid(value: number) {
   expect(value).toBeCloseTo(Math.round(value / SNAP_SIZE) * SNAP_SIZE, 5);
 }
 
-test('dragging and resizing use half-grid increments', async ({ page }) => {
+test('dragging and resizing use half-grid increments and persist across reload', async ({ page }) => {
   await mockApi(page);
   await page.addInitScript(
     ({ canvasKey, canvas }) => {
+      if (window.localStorage.getItem(canvasKey)) {
+        return;
+      }
       window.localStorage.clear();
       window.localStorage.setItem(canvasKey, JSON.stringify(canvas));
       window.localStorage.setItem(
@@ -120,13 +123,15 @@ test('dragging and resizing use half-grid increments', async ({ page }) => {
   expectOnGrid(afterDrag.position.y - beforeDrag.position.y);
 
   const beforeResize = afterDrag;
-  const resizeBox = await node.boundingBox();
-  if (!resizeBox) {
-    throw new Error('Grid node has no bounding box after dragging');
+  const resizeControl = node.locator('.react-flow__resize-control.handle.bottom.right');
+  await expect(resizeControl).toBeVisible();
+  const handleBox = await resizeControl.boundingBox();
+  if (!handleBox) {
+    throw new Error('Bottom-right resize control has no bounding box');
   }
   const resizeStart = {
-    x: resizeBox.x + resizeBox.width,
-    y: resizeBox.y + resizeBox.height,
+    x: handleBox.x + handleBox.width / 2,
+    y: handleBox.y + handleBox.height / 2,
   };
   await page.mouse.move(resizeStart.x, resizeStart.y);
   await page.mouse.down();
@@ -141,4 +146,13 @@ test('dragging and resizing use half-grid increments', async ({ page }) => {
   expectOnGrid(afterResize.style.height);
   expectOnGrid(afterResize.style.width - beforeResize.style.width);
   expectOnGrid(afterResize.style.height - beforeResize.style.height);
+
+  await page.reload();
+  await expect(node).toBeVisible();
+  await expect(node).toHaveCSS('width', `${afterResize.style.width}px`);
+  await expect(node).toHaveCSS('height', `${afterResize.style.height}px`);
+  await page.waitForTimeout(450);
+
+  const afterReload = await storedNode(page);
+  expect(afterReload).toEqual(afterResize);
 });

--- a/frontend/tests/viewport-persistence.spec.ts
+++ b/frontend/tests/viewport-persistence.spec.ts
@@ -1,0 +1,296 @@
+import { appendFileSync } from 'node:fs';
+import { expect, test, type Browser, type Page, type ViewportSize } from '@playwright/test';
+
+const CANVAS_KEY_V1 = 'xscout.canvas.v1';
+const CANVAS_KEY_V2 = 'xscout.canvas.v2';
+const CANVAS_KEY_V3 = 'xscout.canvas.v3';
+const PREFS_KEY = 'xscout.prefs.v1';
+const LOG_PATH = '/opt/cursor/logs/debug.log';
+const RUN_PHASE = process.env.VIEWPORT_TEST_PHASE ?? 'unspecified';
+
+const sourceNode = {
+  id: 'saved-node',
+  type: 'tickerList',
+  position: { x: 1100, y: 700 },
+  style: { width: 560, height: 300 },
+  data: {
+    listId: 'existing-list',
+    name: 'Saved list',
+    tickers: ['AAPL'],
+    rows: [],
+    errors: [],
+    status: 'idle',
+  },
+};
+
+const rawViewport = { x: -800, y: -500, zoom: 0.75 };
+const wideScreen = { width: 1920, height: 1080 };
+const smallScreen = { width: 1280, height: 720 };
+
+type JsonObject = Record<string, unknown>;
+
+type LayoutMeasurement = {
+  screen: ViewportSize;
+  canvas: { width: number; height: number };
+  transform: { x: number; y: number; zoom: number };
+  flowCenter: { x: number; y: number };
+  node: {
+    position: { x: number; y: number };
+    style: { width: number; height: number };
+  } | null;
+  storage: {
+    v1: JsonObject | null;
+    v2: JsonObject | null;
+    v3: JsonObject | null;
+  };
+};
+
+function agentLog(hypothesisId: string, location: string, message: string, data: unknown) {
+  appendFileSync(
+    LOG_PATH,
+    `${JSON.stringify({
+      hypothesisId,
+      location,
+      message,
+      data: { runPhase: RUN_PHASE, value: data },
+      timestamp: Date.now(),
+    })}\n`,
+  );
+}
+
+async function openStoredCanvas(
+  browser: Browser,
+  screen: ViewportSize,
+  storage: { v1?: JsonObject; v2?: JsonObject; v3?: JsonObject },
+): Promise<{ page: Page; close: () => Promise<void> }> {
+  const context = await browser.newContext({ viewport: screen });
+  await context.addInitScript(
+    ({ keys, values }) => {
+      window.localStorage.clear();
+      window.localStorage.setItem(
+        keys.preferences,
+        JSON.stringify({
+          theme: 'light',
+          scrollMode: 'zoom',
+          drawerOpen: false,
+          drawerWidth: 304,
+          showMinimap: false,
+        }),
+      );
+      for (const [name, value] of Object.entries(values)) {
+        if (value !== undefined) {
+          window.localStorage.setItem(keys[name as keyof typeof keys], JSON.stringify(value));
+        }
+      }
+    },
+    {
+      keys: {
+        v1: CANVAS_KEY_V1,
+        v2: CANVAS_KEY_V2,
+        v3: CANVAS_KEY_V3,
+        preferences: PREFS_KEY,
+      },
+      values: storage,
+    },
+  );
+
+  const page = await context.newPage();
+  await page.route('**/api/ticker-lists', async (route) => {
+    if (route.request().method() === 'POST') {
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: 'migrated-list',
+          name: 'Legacy fixture',
+          tickers: ['AAPL'],
+        }),
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        lists: [
+          { id: 'existing-list', name: 'Saved list', tickers: ['AAPL'] },
+          { id: 'migrated-list', name: 'Legacy fixture', tickers: ['AAPL'] },
+        ],
+      }),
+    });
+  });
+  await page.route('**/api/watchlists/performance', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ rows: [], errors: [] }),
+    }),
+  );
+  await page.goto('/');
+  return { page, close: () => context.close() };
+}
+
+async function measure(page: Page, screen: ViewportSize): Promise<LayoutMeasurement> {
+  await page.waitForSelector('.react-flow__node');
+  await page.waitForTimeout(650);
+  return page.evaluate(
+    ({ keys, browserScreen }) => {
+      const flow = document.querySelector('.react-flow');
+      const viewport = document.querySelector('.react-flow__viewport');
+      if (!(flow instanceof HTMLElement) || !(viewport instanceof HTMLElement)) {
+        throw new Error('React Flow did not mount');
+      }
+      const rect = flow.getBoundingClientRect();
+      const matrix = new DOMMatrixReadOnly(getComputedStyle(viewport).transform);
+      const zoom = matrix.a;
+      const storedNode = JSON.parse(
+        window.localStorage.getItem(keys.v3) ??
+          window.localStorage.getItem(keys.v2) ??
+          '{"nodes":[]}',
+      ).nodes?.[0];
+      return {
+        screen: browserScreen,
+        canvas: { width: rect.width, height: rect.height },
+        transform: { x: matrix.e, y: matrix.f, zoom },
+        flowCenter: {
+          x: (rect.width / 2 - matrix.e) / zoom,
+          y: (rect.height / 2 - matrix.f) / zoom,
+        },
+        node: storedNode
+          ? {
+              position: storedNode.position,
+              style: storedNode.style,
+            }
+          : null,
+        storage: {
+          v1: JSON.parse(window.localStorage.getItem(keys.v1) ?? 'null'),
+          v2: JSON.parse(window.localStorage.getItem(keys.v2) ?? 'null'),
+          v3: JSON.parse(window.localStorage.getItem(keys.v3) ?? 'null'),
+        },
+      };
+    },
+    {
+      keys: { v1: CANVAS_KEY_V1, v2: CANVAS_KEY_V2, v3: CANVAS_KEY_V3 },
+      browserScreen: screen,
+    },
+  );
+}
+
+test('migrates raw transforms and preserves flow-space center across resolutions', async ({
+  browser,
+}) => {
+  const v2Fixture = {
+    nodes: [sourceNode],
+    edges: [],
+    viewport: rawViewport,
+  };
+
+  // #region agent log
+  agentLog('H5,H6', 'tests/viewport-persistence.spec.ts:v2-fixture', 'raw v2 fixture', {
+    screenSizes: [wideScreen, smallScreen],
+    viewport: rawViewport,
+    node: { position: sourceNode.position, style: sourceNode.style },
+  });
+  // #endregion
+
+  const wideRun = await openStoredCanvas(browser, wideScreen, { v2: v2Fixture });
+  const wide = await measure(wideRun.page, wideScreen);
+  await wideRun.close();
+  // #region agent log
+  agentLog('H5', 'tests/viewport-persistence.spec.ts:v2-wide', 'raw v2 wide restore', wide);
+  // #endregion
+
+  const smallRun = await openStoredCanvas(browser, smallScreen, { v2: v2Fixture });
+  const small = await measure(smallRun.page, smallScreen);
+  await smallRun.close();
+  // #region agent log
+  agentLog('H5', 'tests/viewport-persistence.spec.ts:v2-small', 'raw v2 small restore', small);
+  // #endregion
+
+  const migratedV3 = wide.storage.v3;
+  let portable: LayoutMeasurement | null = null;
+  if (migratedV3 !== null) {
+    const portableRun = await openStoredCanvas(browser, smallScreen, { v3: migratedV3 });
+    portable = await measure(portableRun.page, smallScreen);
+    await portableRun.close();
+  }
+  // #region agent log
+  agentLog(
+    'H5,H6',
+    'tests/viewport-persistence.spec.ts:v3-portable',
+    'migrated center restore comparison',
+    { wide, portable },
+  );
+  // #endregion
+
+  const legacyFixture = {
+    nodes: [
+      {
+        id: 'legacy-node',
+        type: 'tickerList',
+        position: { x: 1100, y: 700 },
+        style: { width: 560, height: 300 },
+        data: { name: 'Legacy fixture', tickers: ['AAPL'] },
+      },
+    ],
+    edges: [],
+    viewport: rawViewport,
+  };
+  const legacyRun = await openStoredCanvas(browser, smallScreen, { v1: legacyFixture });
+  await legacyRun.page.waitForFunction(
+    (key) => window.localStorage.getItem(key) === null,
+    CANVAS_KEY_V1,
+  );
+  const legacy = await measure(legacyRun.page, smallScreen);
+  await legacyRun.close();
+  // #region agent log
+  agentLog(
+    'H1,H3,H6',
+    'tests/viewport-persistence.spec.ts:legacy',
+    'legacy migration viewport result',
+    legacy,
+  );
+  // #endregion
+
+  const summary = {
+    rawCenterDelta: {
+      x: wide.flowCenter.x - small.flowCenter.x,
+      y: wide.flowCenter.y - small.flowCenter.y,
+    },
+    portableCenterDelta:
+      portable === null
+        ? null
+        : {
+            x: wide.flowCenter.x - portable.flowCenter.x,
+            y: wide.flowCenter.y - portable.flowCenter.y,
+          },
+    migratedV3: migratedV3 !== null,
+    legacyTransform: legacy.transform,
+    legacyV3: legacy.storage.v3 !== null,
+  };
+  // #region agent log
+  agentLog(
+    'H1,H5,H6',
+    'tests/viewport-persistence.spec.ts:summary',
+    'viewport persistence assertions',
+    summary,
+  );
+  // #endregion
+  console.log(JSON.stringify(summary, null, 2));
+
+  expect(Math.abs(summary.rawCenterDelta.x)).toBeGreaterThan(400);
+  expect(Math.abs(summary.rawCenterDelta.y)).toBeGreaterThan(200);
+  expect(migratedV3).not.toBeNull();
+  expect(portable).not.toBeNull();
+  expect(portable?.flowCenter.x).toBeCloseTo(wide.flowCenter.x, 5);
+  expect(portable?.flowCenter.y).toBeCloseTo(wide.flowCenter.y, 5);
+  expect(portable?.node).toEqual({
+    position: sourceNode.position,
+    style: sourceNode.style,
+  });
+  expect(legacy.transform.x).toBeCloseTo(rawViewport.x, 5);
+  expect(legacy.transform.y).toBeCloseTo(rawViewport.y, 5);
+  expect(legacy.transform.zoom).toBeCloseTo(rawViewport.zoom, 5);
+  expect(legacy.storage.v1).toBeNull();
+  expect(legacy.storage.v3).not.toBeNull();
+});

--- a/frontend/tests/viewport-persistence.spec.ts
+++ b/frontend/tests/viewport-persistence.spec.ts
@@ -1,5 +1,9 @@
 import { appendFileSync } from 'node:fs';
 import { expect, test, type Browser, type Page, type ViewportSize } from '@playwright/test';
+import {
+  storedViewportToViewport,
+  viewportToStoredViewport,
+} from '../src/storage/savedLists';
 
 const CANVAS_KEY_V1 = 'xscout.canvas.v1';
 const CANVAS_KEY_V2 = 'xscout.canvas.v2';
@@ -175,6 +179,19 @@ async function measure(page: Page, screen: ViewportSize): Promise<LayoutMeasurem
     },
   );
 }
+
+test('flow-space center is stable at exact 1920x1080 and 1280x720 canvas sizes', () => {
+  const sourceCanvas = { width: 1920, height: 1080 };
+  const targetCanvas = { width: 1280, height: 720 };
+  const stored = viewportToStoredViewport(rawViewport, sourceCanvas);
+  const restored = storedViewportToViewport(stored, targetCanvas);
+  const targetCenter = viewportToStoredViewport(restored, targetCanvas);
+
+  expect(targetCenter.center.x).toBeCloseTo(stored.center.x, 10);
+  expect(targetCenter.center.y).toBeCloseTo(stored.center.y, 10);
+  expect(targetCenter.zoom).toBe(stored.zoom);
+  expect(restored).toEqual({ x: -1120, y: -680, zoom: 0.75 });
+});
 
 test('migrates raw transforms and preserves flow-space center across resolutions', async ({
   browser,

--- a/frontend/tests/viewport-persistence.spec.ts
+++ b/frontend/tests/viewport-persistence.spec.ts
@@ -1,4 +1,3 @@
-import { appendFileSync } from 'node:fs';
 import { expect, test, type Browser, type Page, type ViewportSize } from '@playwright/test';
 import {
   storedViewportToViewport,
@@ -9,8 +8,6 @@ const CANVAS_KEY_V1 = 'xscout.canvas.v1';
 const CANVAS_KEY_V2 = 'xscout.canvas.v2';
 const CANVAS_KEY_V3 = 'xscout.canvas.v3';
 const PREFS_KEY = 'xscout.prefs.v1';
-const LOG_PATH = '/opt/cursor/logs/debug.log';
-const RUN_PHASE = process.env.VIEWPORT_TEST_PHASE ?? 'unspecified';
 
 const sourceNode = {
   id: 'saved-node',
@@ -48,19 +45,6 @@ type LayoutMeasurement = {
     v3: JsonObject | null;
   };
 };
-
-function agentLog(hypothesisId: string, location: string, message: string, data: unknown) {
-  appendFileSync(
-    LOG_PATH,
-    `${JSON.stringify({
-      hypothesisId,
-      location,
-      message,
-      data: { runPhase: RUN_PHASE, value: data },
-      timestamp: Date.now(),
-    })}\n`,
-  );
-}
 
 async function openStoredCanvas(
   browser: Browser,
@@ -202,27 +186,13 @@ test('migrates raw transforms and preserves flow-space center across resolutions
     viewport: rawViewport,
   };
 
-  // #region agent log
-  agentLog('H5,H6', 'tests/viewport-persistence.spec.ts:v2-fixture', 'raw v2 fixture', {
-    screenSizes: [wideScreen, smallScreen],
-    viewport: rawViewport,
-    node: { position: sourceNode.position, style: sourceNode.style },
-  });
-  // #endregion
-
   const wideRun = await openStoredCanvas(browser, wideScreen, { v2: v2Fixture });
   const wide = await measure(wideRun.page, wideScreen);
   await wideRun.close();
-  // #region agent log
-  agentLog('H5', 'tests/viewport-persistence.spec.ts:v2-wide', 'raw v2 wide restore', wide);
-  // #endregion
 
   const smallRun = await openStoredCanvas(browser, smallScreen, { v2: v2Fixture });
   const small = await measure(smallRun.page, smallScreen);
   await smallRun.close();
-  // #region agent log
-  agentLog('H5', 'tests/viewport-persistence.spec.ts:v2-small', 'raw v2 small restore', small);
-  // #endregion
 
   const migratedV3 = wide.storage.v3;
   let portable: LayoutMeasurement | null = null;
@@ -231,14 +201,6 @@ test('migrates raw transforms and preserves flow-space center across resolutions
     portable = await measure(portableRun.page, smallScreen);
     await portableRun.close();
   }
-  // #region agent log
-  agentLog(
-    'H5,H6',
-    'tests/viewport-persistence.spec.ts:v3-portable',
-    'migrated center restore comparison',
-    { wide, portable },
-  );
-  // #endregion
 
   const legacyFixture = {
     nodes: [
@@ -260,14 +222,6 @@ test('migrates raw transforms and preserves flow-space center across resolutions
   );
   const legacy = await measure(legacyRun.page, smallScreen);
   await legacyRun.close();
-  // #region agent log
-  agentLog(
-    'H1,H3,H6',
-    'tests/viewport-persistence.spec.ts:legacy',
-    'legacy migration viewport result',
-    legacy,
-  );
-  // #endregion
 
   const summary = {
     rawCenterDelta: {
@@ -285,15 +239,7 @@ test('migrates raw transforms and preserves flow-space center across resolutions
     legacyTransform: legacy.transform,
     legacyV3: legacy.storage.v3 !== null,
   };
-  // #region agent log
-  agentLog(
-    'H1,H5,H6',
-    'tests/viewport-persistence.spec.ts:summary',
-    'viewport persistence assertions',
-    summary,
-  );
-  // #endregion
-  console.log(JSON.stringify(summary, null, 2));
+  console.log('viewport persistence:', JSON.stringify(summary));
 
   expect(Math.abs(summary.rawCenterDelta.x)).toBeGreaterThan(400);
   expect(Math.abs(summary.rawCenterDelta.y)).toBeGreaterThan(200);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- persist the canvas viewport by flow-space center so it restores consistently across screen sizes
- migrate existing canvas storage and preserve legacy viewport transforms
- persist actual resized node dimensions so arranged cards do not revert or overlap after reload
- snap card dragging and resizing to 11-unit increments, half of the 22-unit dot grid
- add browser regression coverage for viewport migration, cross-resolution restoration, snapping, and resize persistence

## Validation
- `npm run test:canvas` — 3 passed
- `npm run build` — passed
- `.venv/bin/python -m unittest discover -s tests` — 29 passed, 6 skipped
- manual browser walkthrough confirmed final card dimensions and placement survive reload

[canvas_geometry_persists_after_reload.mp4](https://cursor.com/agents/bc-08d93cea-d8f9-40f3-bf6d-b76a11fa3aa6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcanvas_geometry_persists_after_reload.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08d93cea-d8f9-40f3-bf6d-b76a11fa3aa6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08d93cea-d8f9-40f3-bf6d-b76a11fa3aa6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

