### PR TITLE
Add Watts Into Thoughts dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ layout — node positions, edges, viewport — is kept in `localStorage`.
 
 The app fetches live market data from Yahoo Finance through the `yfinance` library.
 
+A **Watts** dashboard (Canvas | Watts in the top bar, also at `/#watts`)
+tracks the "what to watch" items from Michael Nicoletos's *Watts Into
+Thoughts* note: electricity vs oil, grid connection queues, transformer
+lead times, financing conditions, regions with surplus power, data-center
+jurisdiction proxies, and intelligence per unit of energy. Live legs are
+Yahoo Finance total-return proxies; physical constraints (queue TW, wait
+times, token volumes) are dated research snapshots cited on each card.
+Each panel can be saved as a ticker list and pinned on the canvas.
+
 ## Requirements
 
 - Python 3.10+

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -34,6 +34,7 @@ import { ListsDrawer } from './components/ListsDrawer';
 import { OffscreenNotice } from './components/OffscreenNotice';
 import { TickerListNode, type TickerListNodeData } from './components/TickerListNode';
 import { TopBar } from './components/TopBar';
+import { WattsDashboard } from './components/WattsDashboard';
 import { ListsProvider, useLists } from './lists/ListsContext';
 import { PreferencesProvider, usePreferences } from './prefs/PreferencesContext';
 import {
@@ -708,7 +709,7 @@ function Workspace() {
 
   return (
     <div className="app-shell">
-      <TopBar nodeCount={nodes.length} busy={anyLoading} onRefreshAll={refreshAll} />
+      <TopBar variant="canvas" nodeCount={nodes.length} busy={anyLoading} onRefreshAll={refreshAll} />
 
       <div className="workspace">
         {drawerOpen ? (
@@ -802,8 +803,57 @@ export default function App() {
   return (
     <PreferencesProvider>
       <ListsProvider>
-        <Workspace />
+        <AppViews />
       </ListsProvider>
     </PreferencesProvider>
+  );
+}
+
+function AppViews() {
+  const { view, setView } = usePreferences();
+
+  useEffect(() => {
+    const applyHash = () => {
+      const hash = window.location.hash.replace(/^#/, '');
+      if (hash === 'watts') {
+        setView('watts');
+      } else if (hash === 'canvas') {
+        setView('canvas');
+      }
+    };
+    applyHash();
+    window.addEventListener('hashchange', applyHash);
+    return () => window.removeEventListener('hashchange', applyHash);
+  }, [setView]);
+
+  useEffect(() => {
+    const desired = view === 'watts' ? '#watts' : '';
+    if (window.location.hash !== desired) {
+      const url = desired
+        ? `${window.location.pathname}${window.location.search}${desired}`
+        : `${window.location.pathname}${window.location.search}`;
+      window.history.replaceState(null, '', url);
+    }
+  }, [view]);
+
+  if (view === 'watts') {
+    return <WattsView />;
+  }
+  return <Workspace />;
+}
+
+function WattsView() {
+  const [busy, setBusy] = useState(false);
+  const [refreshToken, setRefreshToken] = useState(0);
+
+  return (
+    <div className="app-shell">
+      <TopBar
+        variant="watts"
+        busy={busy}
+        onRefreshAll={() => setRefreshToken((current) => current + 1)}
+      />
+      <WattsDashboard refreshToken={refreshToken} onBusyChange={setBusy} />
+    </div>
   );
 }

--- a/frontend/src/api/watts.ts
+++ b/frontend/src/api/watts.ts
@@ -1,0 +1,70 @@
+export type ChangeCell = {
+  value: number | null;
+  display: string;
+  className: string;
+};
+
+export type WattsInstrumentRow = {
+  ticker: string;
+  name: string;
+  role: string;
+  kind: string;
+  price: string;
+  priceValue: number | null;
+  windows: Record<string, ChangeCell>;
+  sparkline: number[];
+};
+
+export type WattsMetric = {
+  id: string;
+  label: string;
+  value: string;
+  detail: string;
+  asOf: string;
+  source: string;
+};
+
+export type WattsPanel = {
+  id: string;
+  title: string;
+  watch: string;
+  tickers: string[];
+  metrics: WattsMetric[];
+  rows: WattsInstrumentRow[];
+};
+
+export type WattsSpread = {
+  id: string;
+  label: string;
+  description: string;
+  longTickers: string[];
+  shortTickers: string[];
+  windows: Record<string, ChangeCell>;
+  coverage: { long: string[]; short: string[] };
+};
+
+export type WattsDashboardResponse = {
+  generatedAt: string;
+  title: string;
+  subtitle: string;
+  thesis: string;
+  sourceNote: string;
+  northStar: {
+    title: string;
+    lede: string;
+    spreads: WattsSpread[];
+  };
+  panels: WattsPanel[];
+  errors: string[];
+  error?: string;
+};
+
+export async function fetchWattsDashboard(refresh = false): Promise<WattsDashboardResponse> {
+  const suffix = refresh ? '?refresh=1' : '';
+  const response = await fetch(`/api/watts/dashboard${suffix}`);
+  const body = (await response.json().catch(() => ({}))) as WattsDashboardResponse;
+  if (!response.ok) {
+    throw new Error(body.error || `Watts dashboard failed with ${response.status}`);
+  }
+  return body;
+}

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -1,7 +1,9 @@
 import { memo, type ReactNode } from 'react';
 import { usePreferences } from '../prefs/PreferencesContext';
-import type { ScrollMode, ThemeMode } from '../storage/preferences';
+import type { AppView, ScrollMode, ThemeMode } from '../storage/preferences';
 import {
+  BoltIcon,
+  CanvasIcon,
   MonitorIcon,
   MoonIcon,
   PanelIcon,
@@ -12,7 +14,8 @@ import {
 } from './icons';
 
 type TopBarProps = {
-  nodeCount: number;
+  variant: AppView;
+  nodeCount?: number;
   busy: boolean;
   onRefreshAll: () => void;
 };
@@ -28,55 +31,88 @@ const scrollOptions: { value: ScrollMode; label: string; icon: ReactNode }[] = [
   { value: 'pan', label: 'Scroll wheel pans the canvas (⌘/Ctrl + scroll zooms)', icon: <ScrollPanIcon /> },
 ];
 
-function TopBarComponent({ nodeCount, busy, onRefreshAll }: TopBarProps) {
-  const { theme, setTheme, scrollMode, setScrollMode, drawerOpen, setDrawerOpen } =
+function TopBarComponent({ variant, nodeCount = 0, busy, onRefreshAll }: TopBarProps) {
+  const { theme, setTheme, scrollMode, setScrollMode, drawerOpen, setDrawerOpen, view, setView } =
     usePreferences();
+
+  const canvas = variant === 'canvas';
 
   return (
     <header className="topbar">
-      <button
-        type="button"
-        className="icon-button"
-        aria-label={drawerOpen ? 'Hide lists panel' : 'Show lists panel'}
-        aria-pressed={drawerOpen}
-        title={`${drawerOpen ? 'Hide' : 'Show'} lists panel  ( \\ )`}
-        onClick={() => setDrawerOpen(!drawerOpen)}
-      >
-        <PanelIcon />
-      </button>
+      {canvas ? (
+        <button
+          type="button"
+          className="icon-button"
+          aria-label={drawerOpen ? 'Hide lists panel' : 'Show lists panel'}
+          aria-pressed={drawerOpen}
+          title={`${drawerOpen ? 'Hide' : 'Show'} lists panel  ( \\ )`}
+          onClick={() => setDrawerOpen(!drawerOpen)}
+        >
+          <PanelIcon />
+        </button>
+      ) : null}
 
       <div className="topbar__brand">
         <span className="topbar__mark" aria-hidden="true" />
         <h1>xscout</h1>
-        <p>Ticker lists on an infinite canvas</p>
+        <p>{canvas ? 'Ticker lists on an infinite canvas' : 'Electrons into thought'}</p>
       </div>
 
       <div className="topbar__actions">
+        <div className="segmented segmented--text" role="tablist" aria-label="Workspace">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={view === 'canvas'}
+            aria-pressed={view === 'canvas'}
+            title="Ticker canvas"
+            onClick={() => setView('canvas')}
+          >
+            <CanvasIcon />
+            Canvas
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={view === 'watts'}
+            aria-pressed={view === 'watts'}
+            title="Watts Into Thoughts dashboard"
+            onClick={() => setView('watts')}
+          >
+            <BoltIcon />
+            Watts
+          </button>
+        </div>
+
         <button
           type="button"
           className="button button--primary"
           onClick={onRefreshAll}
-          disabled={nodeCount === 0 || busy}
-          title="Refresh every list on the canvas  ( R )"
+          disabled={canvas ? nodeCount === 0 || busy : busy}
+          title={
+            canvas ? 'Refresh every list on the canvas  ( R )' : 'Refresh Watts dashboard quotes'
+          }
         >
           <RefreshIcon className={busy ? 'is-spinning' : undefined} />
-          {busy ? 'Refreshing…' : 'Refresh all'}
+          {busy ? 'Refreshing…' : canvas ? 'Refresh all' : 'Refresh quotes'}
         </button>
 
-        <div className="segmented" role="group" aria-label="Scroll wheel behaviour">
-          {scrollOptions.map((option) => (
-            <button
-              key={option.value}
-              type="button"
-              aria-label={option.label}
-              aria-pressed={scrollMode === option.value}
-              title={option.label}
-              onClick={() => setScrollMode(option.value)}
-            >
-              {option.icon}
-            </button>
-          ))}
-        </div>
+        {canvas ? (
+          <div className="segmented" role="group" aria-label="Scroll wheel behaviour">
+            {scrollOptions.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                aria-label={option.label}
+                aria-pressed={scrollMode === option.value}
+                title={option.label}
+                onClick={() => setScrollMode(option.value)}
+              >
+                {option.icon}
+              </button>
+            ))}
+          </div>
+        ) : null}
 
         <div className="segmented" role="group" aria-label="Colour theme">
           {themeOptions.map((option) => (

--- a/frontend/src/components/WattsDashboard.tsx
+++ b/frontend/src/components/WattsDashboard.tsx
@@ -1,0 +1,300 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  fetchWattsDashboard,
+  type WattsDashboardResponse,
+  type WattsInstrumentRow,
+  type WattsMetric,
+  type WattsPanel,
+  type WattsSpread,
+} from '../api/watts';
+import { useLists } from '../lists/ListsContext';
+import { PlusIcon, RefreshIcon } from './icons';
+
+const TABLE_WINDOWS = ['1D', '1M', '3M', '1Y'] as const;
+
+type WattsDashboardProps = {
+  refreshToken: number;
+  onBusyChange: (busy: boolean) => void;
+};
+
+export function WattsDashboard({ refreshToken, onBusyChange }: WattsDashboardProps) {
+  const listsApi = useLists();
+  const [data, setData] = useState<WattsDashboardResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  const load = useCallback(
+    async (refresh: boolean) => {
+      setLoading(true);
+      onBusyChange(true);
+      setError(null);
+      try {
+        const payload = await fetchWattsDashboard(refresh);
+        setData(payload);
+      } catch (caught) {
+        setError(caught instanceof Error ? caught.message : 'Unable to load the Watts dashboard.');
+      } finally {
+        setLoading(false);
+        onBusyChange(false);
+      }
+    },
+    [onBusyChange],
+  );
+
+  useEffect(() => {
+    void load(refreshToken > 0);
+  }, [load, refreshToken]);
+
+  const generatedLabel = useMemo(() => formatGeneratedAt(data?.generatedAt), [data?.generatedAt]);
+
+  async function addPanelAsList(panel: WattsPanel) {
+    const name = `Watts · ${panel.title}`;
+    const existing = listsApi.lists.find((entry) => entry.name === name);
+    if (existing) {
+      setNotice(`“${name}” is already in your lists. Open Canvas to pin it.`);
+      return;
+    }
+    try {
+      await listsApi.createList({ name, tickers: panel.tickers });
+      setNotice(`Saved “${name}” to your lists. Open Canvas to pin it.`);
+    } catch (caught) {
+      setNotice(caught instanceof Error ? caught.message : 'Could not save that list.');
+    }
+  }
+
+  const listsReady = listsApi.status === 'ready';
+
+  return (
+    <main className="watts" aria-label="Watts Into Thoughts dashboard">
+      <div className="watts__inner">
+        <header className="watts__hero">
+          <p className="watts__kicker">What to watch</p>
+          <h2>Electrons into thought</h2>
+          <p className="watts__lede">
+            {data?.northStar.lede ??
+              'Electricity prices, grid queues, transformer lead times, financing, surplus power, and the cost of operating data centers — and above all, useful intelligence per unit of energy.'}
+          </p>
+          <p className="watts__meta">
+            {generatedLabel ? `Quotes as of ${generatedLabel}` : loading ? 'Loading live proxies…' : 'Live proxies'}
+            <span aria-hidden="true"> · </span>
+            Yahoo Finance total returns, not official MWh or token statistics
+          </p>
+        </header>
+
+        {error ? (
+          <div className="banner banner--error" role="alert">
+            {error}
+          </div>
+        ) : null}
+
+        {data?.errors && data.errors.length > 0 ? (
+          <div className="banner banner--warning" role="status">
+            Some proxies did not load: {data.errors.join(' ')}
+          </div>
+        ) : null}
+
+        {notice ? (
+          <div className="banner watts__notice" role="status">
+            {notice}
+            <button type="button" className="button button--ghost button--sm" onClick={() => setNotice(null)}>
+              Dismiss
+            </button>
+          </div>
+        ) : null}
+
+        {loading && !data ? <WattsSkeleton /> : null}
+
+        {data ? (
+          <>
+            <section className="watts__spreads" aria-label="North-star spreads">
+              {data.northStar.spreads.map((spread) => (
+                <SpreadCard key={spread.id} spread={spread} />
+              ))}
+            </section>
+
+            {data.panels.map((panel) => (
+              <section key={panel.id} className="watts-panel" id={panel.id}>
+                <header className="watts-panel__header">
+                  <div>
+                    <h3>{panel.title}</h3>
+                    <p>{panel.watch}</p>
+                  </div>
+                  {listsReady ? (
+                    <button
+                      type="button"
+                      className="button button--sm"
+                      onClick={() => void addPanelAsList(panel)}
+                      title="Save these tickers as a canvas list"
+                    >
+                      <PlusIcon />
+                      Save as list
+                    </button>
+                  ) : null}
+                </header>
+
+                {panel.metrics.length > 0 ? (
+                  <div className="watts-metrics">
+                    {panel.metrics.map((metric) => (
+                      <MetricCard key={metric.id} metric={metric} />
+                    ))}
+                  </div>
+                ) : null}
+
+                <ProxyTable rows={panel.rows} />
+              </section>
+            ))}
+
+            <footer className="watts__footer">
+              <p>{data.thesis}</p>
+              <p>{data.sourceNote}</p>
+            </footer>
+          </>
+        ) : null}
+      </div>
+    </main>
+  );
+}
+
+function SpreadCard({ spread }: { spread: WattsSpread }) {
+  const headline = spread.windows['1M'] ?? emptyCell();
+  return (
+    <article className="watts-spread">
+      <h3>{spread.label}</h3>
+      <p className={`watts-spread__value ${headline.className}`}>{headline.display}</p>
+      <p className="watts-spread__window">1-month listed-market spread</p>
+      <p className="watts-spread__copy">{spread.description}</p>
+      <dl className="watts-spread__windows">
+        {TABLE_WINDOWS.map((label) => {
+          const cell = spread.windows[label] ?? emptyCell();
+          return (
+            <div key={label}>
+              <dt>{label}</dt>
+              <dd className={cell.className}>{cell.display}</dd>
+            </div>
+          );
+        })}
+      </dl>
+    </article>
+  );
+}
+
+function MetricCard({ metric }: { metric: WattsMetric }) {
+  return (
+    <article className="watts-metric">
+      <h4>{metric.label}</h4>
+      <p className="watts-metric__value">{metric.value}</p>
+      <p className="watts-metric__detail">{metric.detail}</p>
+      <p className="watts-metric__source">
+        {metric.asOf}
+        <span aria-hidden="true"> · </span>
+        {metric.source}
+      </p>
+    </article>
+  );
+}
+
+function ProxyTable({ rows }: { rows: WattsInstrumentRow[] }) {
+  return (
+    <div className="table-wrap watts-table-wrap">
+      <table className="performance-table watts-table" aria-label="Market proxies">
+        <thead>
+          <tr>
+            <th scope="col">Proxy</th>
+            <th scope="col">Last</th>
+            {TABLE_WINDOWS.map((label) => (
+              <th scope="col" key={label}>
+                {label}
+              </th>
+            ))}
+            <th scope="col">Path</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.ticker}>
+              <td>
+                <div className="watts-table__name">
+                  <strong>{row.ticker}</strong>
+                  <span>{row.name}</span>
+                  <em>{row.role}</em>
+                </div>
+              </td>
+              <td>{row.price}</td>
+              {TABLE_WINDOWS.map((label) => {
+                const cell = row.windows[label];
+                return (
+                  <td key={label} className={cell?.className ?? ''}>
+                    {cell?.display ?? 'N/A'}
+                  </td>
+                );
+              })}
+              <td>
+                <Sparkline values={row.sparkline} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function Sparkline({ values }: { values: number[] }) {
+  if (values.length < 2) {
+    return <span className="watts-sparkline watts-sparkline--empty">—</span>;
+  }
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const span = max - min || 1;
+  const width = 88;
+  const height = 28;
+  const pad = 1.5;
+  const points = values.map((value, index) => {
+    const x = pad + (index / (values.length - 1)) * (width - pad * 2);
+    const y = height - pad - ((value - min) / span) * (height - pad * 2);
+    return `${x.toFixed(2)},${y.toFixed(2)}`;
+  });
+  const up = values[values.length - 1] >= values[0];
+  return (
+    <svg
+      className={`watts-sparkline${up ? ' is-up' : ' is-down'}`}
+      viewBox={`0 0 ${width} ${height}`}
+      width={width}
+      height={height}
+      aria-hidden="true"
+    >
+      <polyline fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinejoin="round" points={points.join(' ')} />
+    </svg>
+  );
+}
+
+function WattsSkeleton() {
+  return (
+    <div className="watts-skeleton" aria-hidden="true">
+      <div className="watts__spreads">
+        <div className="watts-spread" />
+        <div className="watts-spread" />
+        <div className="watts-spread" />
+      </div>
+      <p className="watts__meta">
+        <RefreshIcon className="is-spinning" /> Loading electricity, grid, credit, and compute proxies…
+      </p>
+    </div>
+  );
+}
+
+function emptyCell() {
+  return { value: null, display: 'N/A', className: '' };
+}
+
+function formatGeneratedAt(iso: string | undefined): string | null {
+  if (!iso) {
+    return null;
+  }
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+}

--- a/frontend/src/components/icons.tsx
+++ b/frontend/src/components/icons.tsx
@@ -144,6 +144,24 @@ export function TargetIcon(props: SVGProps<SVGSVGElement>) {
   );
 }
 
+export function BoltIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <Glyph
+      {...props}
+      d="M11.2 2.1a1 1 0 0 1 .96.04l.08.06 7 6A1 1 0 0 1 18.6 10H14l3.72 8.38A1 1 0 0 1 16.8 20H9.2a1 1 0 0 1-.92-1.4L12 10H5.4A1 1 0 0 1 4.6 8.2l6-6 .08-.06a1 1 0 0 1 .52-.04ZM8.12 8H13a1 1 0 0 1 .93 1.38L10.7 18h4.08L11.4 10.6A1 1 0 0 1 12.3 9h3.28L12 4.4 8.12 8Z"
+    />
+  );
+}
+
+export function CanvasIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <Glyph
+      {...props}
+      d="M4 5h7a1 1 0 0 1 1 1v5H4V5Zm0 8h8v6H5a1 1 0 0 1-1-1v-5Zm10-3h6v8a1 1 0 0 1-1 1h-5v-9Zm0-5h5a1 1 0 0 1 1 1v3h-6V5Z"
+    />
+  );
+}
+
 export function KeyboardIcon(props: SVGProps<SVGSVGElement>) {
   return (
     <Glyph

--- a/frontend/src/prefs/PreferencesContext.tsx
+++ b/frontend/src/prefs/PreferencesContext.tsx
@@ -11,6 +11,7 @@ import {
   DEFAULT_PREFERENCES,
   loadPreferences,
   savePreferences,
+  type AppView,
   type Preferences,
   type ScrollMode,
   type ThemeMode,
@@ -24,6 +25,7 @@ type PreferencesContextValue = Preferences & {
   setDrawerOpen: (open: boolean) => void;
   setDrawerWidth: (width: number) => void;
   setShowMinimap: (show: boolean) => void;
+  setView: (view: AppView) => void;
 };
 
 const PreferencesContext = createContext<PreferencesContextValue | undefined>(undefined);
@@ -80,6 +82,7 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
       setDrawerOpen: (drawerOpen) => patch({ drawerOpen }),
       setDrawerWidth: (drawerWidth) => patch({ drawerWidth }),
       setShowMinimap: (showMinimap) => patch({ showMinimap }),
+      setView: (view) => patch({ view }),
     }),
     [patch, preferences, resolvedTheme],
   );

--- a/frontend/src/storage/preferences.ts
+++ b/frontend/src/storage/preferences.ts
@@ -3,12 +3,15 @@ export type ThemeMode = 'light' | 'dark' | 'system';
 /** Whether a bare wheel gesture zooms the canvas or pans it (Figma-style). */
 export type ScrollMode = 'zoom' | 'pan';
 
+export type AppView = 'canvas' | 'watts';
+
 export type Preferences = {
   theme: ThemeMode;
   scrollMode: ScrollMode;
   drawerOpen: boolean;
   drawerWidth: number;
   showMinimap: boolean;
+  view: AppView;
 };
 
 // Kept in sync with the inline bootstrap script in index.html, which reads the
@@ -24,6 +27,7 @@ export const DEFAULT_PREFERENCES: Preferences = {
   drawerOpen: true,
   drawerWidth: 304,
   showMinimap: true,
+  view: 'canvas',
 };
 
 function clampDrawerWidth(value: unknown): number {
@@ -49,6 +53,7 @@ export function loadPreferences(): Preferences {
       drawerOpen: typeof parsed.drawerOpen === 'boolean' ? parsed.drawerOpen : true,
       drawerWidth: clampDrawerWidth(parsed.drawerWidth),
       showMinimap: typeof parsed.showMinimap === 'boolean' ? parsed.showMinimap : true,
+      view: parsed.view === 'watts' ? 'watts' : 'canvas',
     };
   } catch {
     return DEFAULT_PREFERENCES;

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -328,6 +328,24 @@ textarea {
   color: var(--accent);
 }
 
+.segmented--text {
+  gap: 2px;
+}
+
+.segmented--text button {
+  font-size: 0.78rem;
+  font-weight: 700;
+  gap: 5px;
+  height: 26px;
+  padding: 0 9px;
+  width: auto;
+}
+
+.segmented--text button svg {
+  height: 13px;
+  width: 13px;
+}
+
 .chip {
   background: var(--surface-muted);
   border: 1px solid var(--border);
@@ -1364,5 +1382,292 @@ kbd {
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
+  }
+}
+
+/* ------------------------------------------------------- watts dashboard */
+
+.watts {
+  background: var(--canvas-bg);
+  min-height: 0;
+  overflow: auto;
+}
+
+.watts__inner {
+  display: grid;
+  gap: 22px;
+  margin: 0 auto;
+  max-width: 1280px;
+  padding: 22px 22px 56px;
+}
+
+.watts__hero h2 {
+  font-size: 1.85rem;
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  line-height: 1.15;
+  margin: 4px 0 8px;
+}
+
+.watts__kicker {
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.watts__lede {
+  color: var(--text-muted);
+  font-size: 1rem;
+  line-height: 1.5;
+  margin: 0;
+  max-width: 46rem;
+}
+
+.watts__meta {
+  align-items: center;
+  color: var(--text-subtle);
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 0.78rem;
+  gap: 6px;
+  margin: 10px 0 0;
+}
+
+.watts__meta svg {
+  height: 14px;
+  width: 14px;
+}
+
+.watts__notice {
+  align-items: center;
+  display: flex;
+  gap: 10px;
+  justify-content: space-between;
+}
+
+.watts__spreads {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.watts-spread,
+.watts-panel,
+.watts-metric {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+}
+
+.watts-spread {
+  display: grid;
+  gap: 4px;
+  padding: 16px 16px 14px;
+}
+
+.watts-spread h3 {
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.watts-spread__value {
+  font-size: 1.85rem;
+  font-variant-numeric: tabular-nums;
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  margin: 2px 0 0;
+}
+
+.watts-spread__window,
+.watts-spread__copy {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  line-height: 1.45;
+  margin: 0;
+}
+
+.watts-spread__copy {
+  margin-top: 6px;
+}
+
+.watts-spread__windows {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin: 12px 0 0;
+}
+
+.watts-spread__windows div {
+  background: var(--surface-muted);
+  border-radius: var(--radius-sm);
+  padding: 6px 8px;
+}
+
+.watts-spread__windows dt {
+  color: var(--text-subtle);
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.watts-spread__windows dd {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  margin: 2px 0 0;
+}
+
+.watts-panel {
+  overflow: hidden;
+}
+
+.watts-panel__header {
+  align-items: flex-start;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  padding: 16px 16px 12px;
+}
+
+.watts-panel__header h3 {
+  font-size: 1.05rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  margin: 0 0 4px;
+}
+
+.watts-panel__header p {
+  color: var(--text-muted);
+  font-size: 0.88rem;
+  line-height: 1.45;
+  margin: 0;
+  max-width: 52rem;
+}
+
+.watts-metrics {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  padding: 0 12px 12px;
+}
+
+.watts-metric {
+  box-shadow: none;
+  padding: 12px 13px;
+}
+
+.watts-metric h4 {
+  color: var(--text-subtle);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  margin: 0 0 6px;
+  text-transform: uppercase;
+}
+
+.watts-metric__value {
+  font-size: 1.25rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  margin: 0 0 6px;
+}
+
+.watts-metric__detail {
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  line-height: 1.45;
+  margin: 0;
+}
+
+.watts-metric__source {
+  color: var(--text-subtle);
+  font-size: 0.7rem;
+  margin: 8px 0 0;
+}
+
+.watts-table-wrap {
+  border-radius: 0;
+  border-top: 1px solid var(--border);
+}
+
+.watts-table__name {
+  display: grid;
+  gap: 1px;
+  min-width: 12rem;
+}
+
+.watts-table__name strong {
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.04em;
+}
+
+.watts-table__name span {
+  color: var(--text);
+  font-size: 0.8rem;
+}
+
+.watts-table__name em {
+  color: var(--text-subtle);
+  font-size: 0.72rem;
+  font-style: normal;
+}
+
+.watts-sparkline {
+  display: block;
+}
+
+.watts-sparkline.is-up {
+  color: var(--positive);
+}
+
+.watts-sparkline.is-down {
+  color: var(--negative);
+}
+
+.watts-sparkline--empty {
+  color: var(--text-subtle);
+}
+
+.watts__footer {
+  color: var(--text-muted);
+  display: grid;
+  gap: 8px;
+  padding: 4px 2px 12px;
+}
+
+.watts__footer p {
+  font-size: 0.82rem;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.watts-skeleton .watts-spread {
+  min-height: 160px;
+}
+
+@media (max-width: 960px) {
+  .watts__spreads {
+    grid-template-columns: 1fr;
+  }
+
+  .topbar .segmented--text button {
+    padding: 0 8px;
+  }
+}
+
+@media (max-width: 700px) {
+  .watts__inner {
+    padding: 16px 12px 40px;
+  }
+
+  .watts-panel__header {
+    flex-direction: column;
   }
 }

--- a/tests/test_watts.py
+++ b/tests/test_watts.py
@@ -1,0 +1,160 @@
+"""Unit tests for the Watts Into Thoughts dashboard (no network)."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from xscout import watts
+from xscout.app import app
+from xscout.market_data import compute_performance
+
+
+def _closes(start: float, daily_return: float, count: int = 260) -> list[float]:
+    values = [start]
+    for _ in range(count - 1):
+        values.append(values[-1] * (1 + daily_return))
+    return values
+
+
+class EqualWeightAndSpreadTests(unittest.TestCase):
+    def test_equal_weight_return_averages_available_names(self) -> None:
+        histories = {
+            "AAA": _closes(100, 0.01),
+            "BBB": _closes(100, 0.00),
+        }
+        averaged = watts.equal_weight_return(histories, ["AAA", "BBB", "MISSING"], 1)
+        expected = (
+            compute_performance(histories["AAA"], 1) + compute_performance(histories["BBB"], 1)
+        ) / 2
+        self.assertIsNotNone(averaged)
+        assert averaged is not None
+        self.assertAlmostEqual(averaged, expected)
+
+    def test_spread_is_long_minus_short(self) -> None:
+        histories = {
+            "NVDA": _closes(100, 0.02),
+            "XLE": _closes(100, 0.01),
+        }
+        long_leg = watts.equal_weight_return(histories, ["NVDA"], 21)
+        short_leg = watts.equal_weight_return(histories, ["XLE"], 21)
+        spread = watts.spread_return(histories, ["NVDA"], ["XLE"], 21)
+        self.assertIsNotNone(spread)
+        assert spread is not None and long_leg is not None and short_leg is not None
+        self.assertAlmostEqual(spread, long_leg - short_leg)
+
+    def test_spread_returns_none_without_both_legs(self) -> None:
+        self.assertIsNone(watts.spread_return({"NVDA": _closes(100, 0.01)}, ["NVDA"], ["XLE"], 1))
+
+
+class SparklineTests(unittest.TestCase):
+    def test_sparkline_passthrough_when_short(self) -> None:
+        self.assertEqual(watts.sparkline_values([1.0, 2.0, 3.0], points=10), [1.0, 2.0, 3.0])
+
+    def test_sparkline_downsamples_to_requested_length(self) -> None:
+        sampled = watts.sparkline_values(list(range(200)), points=60)
+        self.assertEqual(len(sampled), 60)
+        self.assertEqual(sampled[0], 0.0)
+        self.assertEqual(sampled[-1], 199.0)
+
+
+class FormatLevelTests(unittest.TestCase):
+    def test_yield_uses_percent_not_dollars(self) -> None:
+        self.assertEqual(watts.format_level(4.251, "yield"), "4.25%")
+
+    def test_price_uses_currency(self) -> None:
+        self.assertEqual(watts.format_level(12.5, "price"), "$12.50")
+
+
+class DashboardAssemblyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        watts.clear_cache()
+        self.histories = {ticker: _closes(100 + index, 0.001) for index, ticker in enumerate(watts.all_tickers())}
+
+    def tearDown(self) -> None:
+        watts.clear_cache()
+
+    def test_build_dashboard_includes_every_watch_panel(self) -> None:
+        payload = watts.build_dashboard(self.histories, use_cache=False)
+        panel_ids = [panel["id"] for panel in payload["panels"]]
+        self.assertEqual(
+            panel_ids,
+            [
+                "electricity-prices",
+                "grid-queues",
+                "transformer-lead-times",
+                "financing-conditions",
+                "surplus-power",
+                "data-center-jurisdictions",
+                "intelligence-per-watt",
+            ],
+        )
+        spread_ids = [spread["id"] for spread in payload["northStar"]["spreads"]]
+        self.assertEqual(spread_ids, ["compute-spread", "power-vs-oil", "spark-proxy"])
+        self.assertTrue(payload["panels"][0]["metrics"])
+        self.assertEqual(payload["errors"], [])
+        first_row = payload["panels"][0]["rows"][0]
+        self.assertIn("1M", first_row["windows"])
+        self.assertIn("display", first_row["windows"]["1M"])
+
+    def test_ten_year_yield_is_not_formatted_as_dollars(self) -> None:
+        payload = watts.build_dashboard(self.histories, use_cache=False)
+        financing = next(panel for panel in payload["panels"] if panel["id"] == "financing-conditions")
+        tnx = next(row for row in financing["rows"] if row["ticker"] == "^TNX")
+        self.assertTrue(tnx["price"].endswith("%"))
+        self.assertFalse(tnx["price"].startswith("$"))
+
+    def test_live_fetch_is_used_when_histories_omitted(self) -> None:
+        def fake_fetch(tickers: list[str]) -> tuple[dict[str, list[float]], list[str]]:
+            return {ticker: _closes(50, 0.0) for ticker in tickers}, ["skipping DEMO"]
+
+        payload = watts.build_dashboard(fetch=fake_fetch, use_cache=False)
+        self.assertIn("skipping DEMO", payload["errors"])
+        self.assertEqual(len(payload["panels"]), 7)
+
+    def test_cache_returns_same_object_within_ttl(self) -> None:
+        first = watts.build_dashboard(self.histories, use_cache=True)
+        second = watts.build_dashboard(use_cache=True)
+        self.assertIs(first, second)
+        watts.clear_cache()
+        third = watts.build_dashboard(self.histories, use_cache=True)
+        self.assertIsNot(first, third)
+
+
+class WattsApiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = app.test_client()
+        watts.clear_cache()
+
+    def tearDown(self) -> None:
+        watts.clear_cache()
+
+    def test_dashboard_endpoint_returns_payload(self) -> None:
+        stub = {
+            "generatedAt": "2026-08-23T00:00:00+00:00",
+            "title": "Watts Into Thoughts",
+            "panels": [],
+            "northStar": {"spreads": []},
+            "errors": [],
+        }
+        with patch("xscout.watts.build_dashboard", return_value=stub) as builder:
+            response = self.client.get("/api/watts/dashboard")
+
+        self.assertEqual(response.status_code, 200)
+        builder.assert_called_once_with(use_cache=True)
+        body = response.get_json()
+        self.assertEqual(body["title"], "Watts Into Thoughts")
+
+    def test_refresh_query_busts_cache(self) -> None:
+        stub = {"title": "Watts Into Thoughts", "errors": []}
+        with patch("xscout.watts.build_dashboard", return_value=stub) as builder:
+            with patch("xscout.watts.clear_cache") as clear:
+                response = self.client.get("/api/watts/dashboard?refresh=1")
+
+        self.assertEqual(response.status_code, 200)
+        clear.assert_called_once()
+        builder.assert_called_once_with(use_cache=False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/xscout/app.py
+++ b/xscout/app.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import flask
 
-from . import db, ticker_lists
+from . import db, ticker_lists, watts
 from .formatting import (
     format_currency,
     format_market_cap,
@@ -64,6 +64,20 @@ def watchlist_performance() -> flask.Response:
             "errors": errors,
         }
     )
+
+
+@app.get("/api/watts/dashboard")
+def watts_dashboard() -> flask.Response:
+    """Live proxies + research snapshots for the Watts Into Thoughts dashboard."""
+    refresh = flask.request.args.get("refresh", "").lower() in {"1", "true", "yes"}
+    try:
+        if refresh:
+            watts.clear_cache()
+        payload = watts.build_dashboard(use_cache=not refresh)
+    except Exception:
+        LOGGER.exception("Failed to build Watts dashboard")
+        return flask.jsonify({"error": "Failed to load the Watts dashboard."}), 500
+    return flask.jsonify(payload)
 
 
 @app.get("/api/ticker-lists")

--- a/xscout/watts.py
+++ b/xscout/watts.py
@@ -1,0 +1,667 @@
+"""Watts Into Thoughts dashboard: intelligence per unit of energy.
+
+Tracks the "what to watch" items from Michael Nicoletos's August 2026 note
+(drawing on Raoul Pal / Global Macro Investor and Ribbit Capital's Power
+Letter) using live Yahoo Finance proxies plus dated research snapshots for
+physical constraints that are not listed securities.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable, Sequence
+
+import yfinance as yf
+
+from .formatting import format_currency, format_percent, performance_class
+from .market_data import compute_performance
+
+LOGGER = logging.getLogger(__name__)
+
+CACHE_TTL_SECONDS = 300
+DASHBOARD_WINDOWS: tuple[tuple[str, int], ...] = (
+    ("1D", 1),
+    ("1M", 21),
+    ("3M", 63),
+    ("6M", 126),
+    ("1Y", 252),
+)
+SPARKLINE_POINTS = 60
+
+FetchHistories = Callable[[Sequence[str]], tuple[dict[str, list[float]], list[str]]]
+
+
+@dataclass(frozen=True)
+class Instrument:
+    ticker: str
+    name: str
+    role: str
+    kind: str = "price"  # "price" or "yield"
+
+
+@dataclass(frozen=True)
+class ResearchMetric:
+    id: str
+    label: str
+    value: str
+    detail: str
+    as_of: str
+    source: str
+
+
+@dataclass(frozen=True)
+class PanelSpec:
+    id: str
+    title: str
+    watch: str
+    instruments: tuple[Instrument, ...]
+    metrics: tuple[ResearchMetric, ...] = ()
+
+
+@dataclass(frozen=True)
+class SpreadSpec:
+    id: str
+    label: str
+    description: str
+    long_tickers: tuple[str, ...]
+    short_tickers: tuple[str, ...]
+
+
+# ---------------------------------------------------------------------------
+# Catalog
+# ---------------------------------------------------------------------------
+
+OIL = Instrument("CL=F", "WTI crude", "Still the old world benchmark")
+BRENT = Instrument("BZ=F", "Brent crude", "International oil benchmark")
+GAS = Instrument("NG=F", "Henry Hub gas", "Fuel for much of US thermal power")
+XLE = Instrument("XLE", "Energy Select", "Oil & gas producers")
+XLU = Instrument("XLU", "Utilities Select", "Regulated electricity complex")
+URA = Instrument("URA", "Uranium miners", "Fuel for firm, low-carbon power")
+VST = Instrument("VST", "Vistra", "Texas independent power / ERCOT")
+CEG = Instrument("CEG", "Constellation", "Largest US nuclear generator")
+NEE = Instrument("NEE", "NextEra Energy", "US renewables + regulated utility")
+NRG = Instrument("NRG", "NRG Energy", "Competitive power, Texas & East")
+
+GEV = Instrument("GEV", "GE Vernova", "Grid equipment, turbines, transformers")
+POWL = Instrument("POWL", "Powell Industries", "Electrical switchgear & substations")
+HUBB = Instrument("HUBB", "Hubbell", "Electrical infrastructure hardware")
+EMR = Instrument("EMR", "Emerson", "Automation and grid-adjacent systems")
+ETN = Instrument("ETN", "Eaton", "Power management and electrical gear")
+VRT = Instrument("VRT", "Vertiv", "Data-center cooling and power")
+
+TNX = Instrument("^TNX", "US 10-year yield", "Risk-free rate that sets financing cost", kind="yield")
+HYG = Instrument("HYG", "High-yield credit", "Junk bond proxy; risk appetite")
+LQD = Instrument("LQD", "IG corporate credit", "Investment-grade financing conditions")
+TLT = Instrument("TLT", "Long Treasuries", "Duration; inverse to long rates")
+KKR = Instrument("KKR", "KKR", "Nvidia AI infrastructure financing partner")
+BX = Instrument("BX", "Blackstone", "Nvidia AI infrastructure financing partner")
+APO = Instrument("APO", "Apollo", "Nvidia AI infrastructure financing partner")
+BLK = Instrument("BLK", "BlackRock", "Nvidia AI infrastructure financing partner")
+
+IBE = Instrument("IBE.MC", "Iberdrola", "Iberian renewables + networks")
+ENGI = Instrument("ENGI.PA", "Engie", "European generation and infrastructure")
+EQNR = Instrument("EQNR", "Equinor", "Nordic energy, hydro-adjacent Norway")
+FORTUM = Instrument("FORTUM.HE", "Fortum", "Nordic hydro and nuclear")
+
+EQIX = Instrument("EQIX", "Equinix", "Global interconnection data centers")
+DLR = Instrument("DLR", "Digital Realty", "Wholesale / hyperscale data centers")
+MSFT = Instrument("MSFT", "Microsoft", "Hyperscale cloud / OpenAI host")
+GOOGL = Instrument("GOOGL", "Alphabet", "Hyperscale cloud + Gemini tokens")
+AMZN = Instrument("AMZN", "Amazon", "AWS hyperscale")
+ORCL = Instrument("ORCL", "Oracle", "Cloud backlog / AI training clusters")
+META = Instrument("META", "Meta", "Training clusters and open models")
+
+NVDA = Instrument("NVDA", "NVIDIA", "Work per watt at the chip layer")
+AVGO = Instrument("AVGO", "Broadcom", "Custom accelerators and networking")
+TSM = Instrument("TSM", "TSMC", "Leading-edge silicon capacity")
+AMD = Instrument("AMD", "AMD", "Alternative accelerators")
+
+INSTRUMENTS: dict[str, Instrument] = {
+    inst.ticker: inst
+    for inst in (
+        OIL,
+        BRENT,
+        GAS,
+        XLE,
+        XLU,
+        URA,
+        VST,
+        CEG,
+        NEE,
+        NRG,
+        GEV,
+        POWL,
+        HUBB,
+        EMR,
+        ETN,
+        VRT,
+        TNX,
+        HYG,
+        LQD,
+        TLT,
+        KKR,
+        BX,
+        APO,
+        BLK,
+        IBE,
+        ENGI,
+        EQNR,
+        FORTUM,
+        EQIX,
+        DLR,
+        MSFT,
+        GOOGL,
+        AMZN,
+        ORCL,
+        META,
+        NVDA,
+        AVGO,
+        TSM,
+        AMD,
+    )
+}
+
+PANELS: tuple[PanelSpec, ...] = (
+    PanelSpec(
+        id="electricity-prices",
+        title="Electricity prices",
+        watch="Focus more on electricity prices than on oil alone.",
+        instruments=(OIL, BRENT, GAS, XLE, XLU, URA, VST, CEG, NEE),
+        metrics=(
+            ResearchMetric(
+                id="europe-power-premium",
+                label="Europe vs US power",
+                value="2–3×",
+                detail="European industrial electricity prices run two to three times US levels; gas four to five times. Every unit of intelligence produced on expensive power costs more to run.",
+                as_of="2024–2025",
+                source="Draghi report on competitiveness",
+            ),
+            ResearchMetric(
+                id="negative-price-hours",
+                label="Negative wholesale hours",
+                value="573 / 500+",
+                detail="Germany recorded 573 hours of negative wholesale electricity prices in 2025; Spain passed 500. Surplus power is real — connecting it to compute is the constraint.",
+                as_of="2025",
+                source="Bloomberg (Jan 2026)",
+            ),
+        ),
+    ),
+    PanelSpec(
+        id="grid-queues",
+        title="Grid connection queues",
+        watch="Watch grid connection queues — the backlog of projects waiting to join the wire.",
+        instruments=(GEV, NEE, VST, CEG, ETN),
+        metrics=(
+            ResearchMetric(
+                id="us-queue-tw",
+                label="US interconnection queue",
+                value="2.06 TW",
+                detail="Peaked near 2.6 TW in 2023. Still about 50% more than all generating capacity America has ever built. Most queued projects will never be completed.",
+                as_of="End of 2025",
+                source="Lawrence Berkeley National Laboratory, Queued Up 2026",
+            ),
+            ResearchMetric(
+                id="median-wait",
+                label="Median wait, completed projects",
+                value=">5 years",
+                detail="Projects finished in 2025 waited a median of more than five years from application to operation. Money can still slow the cycle; delivery of permits and interconnects is tighter.",
+                as_of="2025",
+                source="Lawrence Berkeley National Laboratory",
+            ),
+            ResearchMetric(
+                id="dc-power-demand",
+                label="Data-center power demand",
+                value="+175%",
+                detail="Goldman Sachs expects global data-center power demand to rise about 175% by 2030 from 2023 levels.",
+                as_of="2025 research",
+                source="Goldman Sachs Research",
+            ),
+        ),
+    ),
+    PanelSpec(
+        id="transformer-lead-times",
+        title="Transformer lead times",
+        watch="Watch transformer lead times — the hardware that has to exist before a watt becomes a thought.",
+        instruments=(GEV, POWL, HUBB, EMR, ETN, VRT),
+        metrics=(
+            ResearchMetric(
+                id="musk-sequence",
+                label="Constraint sequence",
+                value="Chips → iron → watts",
+                detail="Elon Musk warned the constraint would move from chips to transformers to electricity itself, joking the industry was running out of transformers to run transformers. Once that shortage is solved, the fundamental shortage is power generation.",
+                as_of="2024–2025",
+                source="CNBC / public remarks",
+            ),
+            ResearchMetric(
+                id="amodei-gw",
+                label="US AI electric capacity",
+                value="≥50 GW by 2028",
+                detail="Anthropic's Dario Amodei has told Washington the American AI sector alone will need at least 50 gigawatts by 2028 — roughly twice New York City's peak demand.",
+                as_of="2025",
+                source="Anthropic, Build AI in America",
+            ),
+        ),
+    ),
+    PanelSpec(
+        id="financing-conditions",
+        title="Financing conditions",
+        watch="Watch financing conditions — the buildout no longer depends on tech cash flows alone.",
+        instruments=(TNX, HYG, LQD, TLT, KKR, BX, APO, BLK),
+        metrics=(
+            ResearchMetric(
+                id="nvidia-credit",
+                label="AI infrastructure credit",
+                value=">$500B",
+                detail="In August 2026 Nvidia announced financing platforms with Apollo, BlackRock, Blackstone, Brookfield, Goldman Sachs and KKR, treating chips and data centers as long-lived assets that can be borrowed against. Skeptics note chips age quickly and some financing is circular.",
+                as_of="August 2026",
+                source="Nvidia / Guardian / CNBC",
+            ),
+            ResearchMetric(
+                id="cloud-backlog",
+                label="Signed cloud backlog",
+                value="$1.8T+",
+                detail="Microsoft, Google and Oracle alone reported more than $1.8 trillion of signed cloud contracts still waiting to be delivered by mid-2026.",
+                as_of="Mid-2026",
+                source="Company filings / Nicoletos compilation",
+            ),
+        ),
+    ),
+    PanelSpec(
+        id="surplus-power",
+        title="Regions with reliable surplus power",
+        watch="Watch regions with reliable surplus power — cost and speed of operating there will decide who scales.",
+        instruments=(VST, CEG, NRG, IBE, ENGI, EQNR, FORTUM, NEE),
+        metrics=(
+            ResearchMetric(
+                id="france-nuclear",
+                label="France nuclear fleet",
+                value="57 reactors",
+                detail="About two-thirds of French electricity, the highest nuclear share in the world: a large base of cheap, low-carbon firm power.",
+                as_of="IAEA PRIS",
+                source="IAEA PRIS / Nicoletos",
+            ),
+            ResearchMetric(
+                id="us-vs-europe-twh",
+                label="Data-center demand to 2030",
+                value="+240 vs +45 TWh",
+                detail="IEA expects data-center electricity demand to grow by about 240 TWh in the United States by 2030, compared with about 45 TWh in Europe. The US already used ~45% of global data-center electricity in 2024 vs ~15% for Europe and ~25% for China.",
+                as_of="2024–2026",
+                source="International Energy Agency",
+            ),
+        ),
+    ),
+    PanelSpec(
+        id="data-center-jurisdictions",
+        title="Where data centers get built",
+        watch="Data centers will be built across many jurisdictions, because speed, resilience, security, regulation and customer preference all favor regional capacity.",
+        instruments=(EQIX, DLR, VRT, MSFT, GOOGL, AMZN, ORCL, META),
+        metrics=(
+            ResearchMetric(
+                id="capex-race",
+                label="Hyperscale capex",
+                value="$400B → +75%",
+                detail="IEA: capital spending by the largest technology companies passed $400 billion in 2025 and is expected to rise about 75% in 2026. Five tech companies now outspend global oil and gas production investment. McKinsey: $6.7T of data-center investment by 2030, $5.2T of it for AI.",
+                as_of="2025–2026",
+                source="IEA; McKinsey, The cost of compute",
+            ),
+            ResearchMetric(
+                id="investai",
+                label="Europe InvestAI",
+                value="€200B / €20B",
+                detail="InvestAI aims to mobilize €200 billion for European AI, including €20 billion for a first wave of four to five AI gigafactories. The Commission estimates about €584 billion of electricity grid investment is needed by 2030 — a requirement, not a funded budget.",
+                as_of="2025–2026",
+                source="European Commission",
+            ),
+        ),
+    ),
+    PanelSpec(
+        id="intelligence-per-watt",
+        title="Useful intelligence per unit of energy",
+        watch="Above all, watch how much useful intelligence the world extracts from each unit of energy.",
+        instruments=(NVDA, AVGO, TSM, AMD, MSFT, GOOGL, XLU, VST),
+        metrics=(
+            ResearchMetric(
+                id="energy-per-task",
+                label="Energy per AI task",
+                value="~10× cheaper / year",
+                detail="The IEA describes the recent fall in energy used per AI task as unprecedented in energy history, with energy needed per task dropping around tenfold each year. Pal's thesis: every system evolves toward maximum intelligence per unit of energy.",
+                as_of="2025–2026",
+                source="IEA, Energy and AI; Raoul Pal, GMI",
+            ),
+            ResearchMetric(
+                id="google-tokens",
+                label="Google token volume",
+                value="~330× in 2 years",
+                detail="Tokens processed across Google products: 9.7 trillion (May 2024) → 480 trillion (May 2025) → 3.2 quadrillion (May 2026). Cheaper intelligence has not shrunk spending (Jevons).",
+                as_of="May 2026",
+                source="Google I/O 2026 / Sundar Pichai",
+            ),
+            ResearchMetric(
+                id="revenue-per-mw",
+                label="Revenue per MW (modeled)",
+                value="$16M → $60M",
+                detail="SemiAnalysis models Anthropic revenue per megawatt of compute at about $16 million in late 2025, heading toward $60 million in 2026, with gross margin moving from deeply negative toward the mid-60s. Outside estimates, not audited numbers.",
+                as_of="2025–2026",
+                source="SemiAnalysis",
+            ),
+        ),
+    ),
+)
+
+SPREADS: tuple[SpreadSpec, ...] = (
+    SpreadSpec(
+        id="compute-spread",
+        label="Compute vs energy",
+        description="Ribbit's compute spread, proxied: equal-weight AI silicon and hyperscalers minus oil, utilities, and power generators. The gap between the value of machine work and the energy required to produce it.",
+        long_tickers=("NVDA", "AVGO", "TSM", "MSFT", "GOOGL"),
+        short_tickers=("XLE", "XLU", "VST", "CEG"),
+    ),
+    SpreadSpec(
+        id="power-vs-oil",
+        label="Power vs oil",
+        description="Electricity-side generators minus crude and energy producers. Positive when the market values watts more than barrels.",
+        long_tickers=("VST", "CEG", "NEE", "XLU"),
+        short_tickers=("CL=F", "XLE"),
+    ),
+    SpreadSpec(
+        id="spark-proxy",
+        label="Power vs gas",
+        description="A listed-market echo of the spark spread: competitive generators minus Henry Hub. Thermal plants live on this gap.",
+        long_tickers=("VST", "NRG", "CEG"),
+        short_tickers=("NG=F",),
+    ),
+)
+
+_cache_lock = threading.Lock()
+_cache: dict[str, object] = {"payload": None, "expires": 0.0}
+
+
+def all_tickers() -> list[str]:
+    seen: list[str] = []
+    for panel in PANELS:
+        for inst in panel.instruments:
+            if inst.ticker not in seen:
+                seen.append(inst.ticker)
+    for spread in SPREADS:
+        for ticker in (*spread.long_tickers, *spread.short_tickers):
+            if ticker not in seen:
+                seen.append(ticker)
+    return seen
+
+
+def equal_weight_return(histories: dict[str, list[float]], tickers: Sequence[str], days: int) -> float | None:
+    """Average percent return across tickers that have enough history."""
+    returns: list[float] = []
+    for ticker in tickers:
+        closes = histories.get(ticker)
+        if not closes:
+            continue
+        value = compute_performance(closes, days)
+        if value is not None:
+            returns.append(value)
+    if not returns:
+        return None
+    return sum(returns) / len(returns)
+
+
+def spread_return(
+    histories: dict[str, list[float]],
+    long_tickers: Sequence[str],
+    short_tickers: Sequence[str],
+    days: int,
+) -> float | None:
+    long_leg = equal_weight_return(histories, long_tickers, days)
+    short_leg = equal_weight_return(histories, short_tickers, days)
+    if long_leg is None or short_leg is None:
+        return None
+    return long_leg - short_leg
+
+
+def sparkline_values(closes: Sequence[float], points: int = SPARKLINE_POINTS) -> list[float]:
+    if not closes:
+        return []
+    if len(closes) <= points:
+        return [round(value, 6) for value in closes]
+    step = (len(closes) - 1) / (points - 1)
+    sampled: list[float] = []
+    for index in range(points):
+        source = min(len(closes) - 1, int(round(index * step)))
+        sampled.append(round(closes[source], 6))
+    return sampled
+
+
+def format_level(value: float | None, kind: str) -> str:
+    if value is None:
+        return "N/A"
+    if kind == "yield":
+        return f"{value:.2f}%"
+    return format_currency(value)
+
+
+def fetch_close_histories(tickers: Sequence[str]) -> tuple[dict[str, list[float]], list[str]]:
+    unique = list(dict.fromkeys(tickers))
+    histories: dict[str, list[float]] = {}
+    errors: list[str] = []
+    if not unique:
+        return histories, errors
+
+    try:
+        frame = yf.download(
+            tickers=unique,
+            period="2y",
+            interval="1d",
+            auto_adjust=True,
+            progress=False,
+            threads=True,
+            timeout=20,
+            group_by="ticker",
+        )
+        histories.update(_closes_from_download(frame, unique))
+    except Exception as exc:  # pragma: no cover - network/library failures
+        LOGGER.exception("Batch Yahoo download failed")
+        errors.append(f"Batch download failed: {exc}")
+
+    missing = [ticker for ticker in unique if ticker not in histories]
+    for ticker in missing:
+        try:
+            history = yf.Ticker(ticker).history(period="2y", interval="1d", auto_adjust=True)
+            closes = _series_to_closes(history["Close"] if "Close" in history else None)
+            if len(closes) >= 2:
+                histories[ticker] = closes
+            else:
+                errors.append(f"No quote data for {ticker}.")
+        except Exception as exc:  # pragma: no cover
+            errors.append(f"Skipping {ticker}: {exc}")
+    return histories, errors
+
+
+def _series_to_closes(series: object) -> list[float]:
+    if series is None:
+        return []
+    values: list[float] = []
+    try:
+        dropped = series.dropna()
+        for value in dropped.tolist():
+            number = float(value)
+            if number == number:  # not NaN
+                values.append(number)
+    except Exception:
+        return []
+    return values
+
+
+def _closes_from_download(frame: object, tickers: Sequence[str]) -> dict[str, list[float]]:
+    result: dict[str, list[float]] = {}
+    if frame is None:
+        return result
+    empty = getattr(frame, "empty", True)
+    if empty:
+        return result
+
+    columns = getattr(frame, "columns", None)
+    if columns is None:
+        return result
+
+    if getattr(columns, "nlevels", 1) > 1:
+        level_zero = {str(value) for value in columns.get_level_values(0)}
+        for ticker in tickers:
+            closes: list[float] = []
+            try:
+                if ticker in level_zero:
+                    sub = frame[ticker]
+                    if hasattr(sub, "columns") and "Close" in sub.columns:
+                        closes = _series_to_closes(sub["Close"])
+                elif "Close" in level_zero:
+                    closes = _series_to_closes(frame["Close"][ticker])
+            except Exception:
+                continue
+            if len(closes) >= 2:
+                result[ticker] = closes
+        return result
+
+    if "Close" in columns and len(tickers) == 1:
+        closes = _series_to_closes(frame["Close"])
+        if len(closes) >= 2:
+            result[tickers[0]] = closes
+    return result
+
+
+def instrument_row(instrument: Instrument, closes: Sequence[float]) -> dict[str, object]:
+    price = closes[-1] if closes else None
+    performance: dict[str, object] = {}
+    for label, days in DASHBOARD_WINDOWS:
+        change = compute_performance(closes, days) if closes else None
+        performance[label] = {
+            "value": change,
+            "display": format_percent(change),
+            "className": performance_class(change),
+        }
+    return {
+        "ticker": instrument.ticker,
+        "name": instrument.name,
+        "role": instrument.role,
+        "kind": instrument.kind,
+        "price": format_level(price, instrument.kind),
+        "priceValue": price,
+        "windows": performance,
+        "sparkline": sparkline_values(closes),
+    }
+
+
+def serialize_spread(spec: SpreadSpec, histories: dict[str, list[float]]) -> dict[str, object]:
+    windows: dict[str, object] = {}
+    for label, days in DASHBOARD_WINDOWS:
+        change = spread_return(histories, spec.long_tickers, spec.short_tickers, days)
+        windows[label] = {
+            "value": change,
+            "display": format_percent(change),
+            "className": performance_class(change),
+        }
+    return {
+        "id": spec.id,
+        "label": spec.label,
+        "description": spec.description,
+        "longTickers": list(spec.long_tickers),
+        "shortTickers": list(spec.short_tickers),
+        "windows": windows,
+        "coverage": {
+            "long": [ticker for ticker in spec.long_tickers if ticker in histories],
+            "short": [ticker for ticker in spec.short_tickers if ticker in histories],
+        },
+    }
+
+
+def serialize_metric(metric: ResearchMetric) -> dict[str, str]:
+    return {
+        "id": metric.id,
+        "label": metric.label,
+        "value": metric.value,
+        "detail": metric.detail,
+        "asOf": metric.as_of,
+        "source": metric.source,
+    }
+
+
+def serialize_panel(spec: PanelSpec, histories: dict[str, list[float]]) -> dict[str, object]:
+    rows = [
+        instrument_row(instrument, histories.get(instrument.ticker, []))
+        for instrument in spec.instruments
+    ]
+    return {
+        "id": spec.id,
+        "title": spec.title,
+        "watch": spec.watch,
+        "tickers": [instrument.ticker for instrument in spec.instruments],
+        "metrics": [serialize_metric(metric) for metric in spec.metrics],
+        "rows": rows,
+    }
+
+
+def build_dashboard(
+    histories: dict[str, list[float]] | None = None,
+    errors: list[str] | None = None,
+    *,
+    fetch: FetchHistories | None = None,
+    use_cache: bool = True,
+) -> dict[str, object]:
+    """Assemble the Watts dashboard payload.
+
+    Pass `histories` to skip the network (tests). Live calls cache for
+    CACHE_TTL_SECONDS so the UI can refresh without hammering Yahoo.
+    """
+    if histories is None and use_cache:
+        with _cache_lock:
+            payload = _cache["payload"]
+            expires = float(_cache["expires"])
+            if payload is not None and expires > time.time():
+                return payload  # type: ignore[return-value]
+
+    fetch_errors: list[str] = list(errors or [])
+    if histories is None:
+        fetcher = fetch or fetch_close_histories
+        histories, network_errors = fetcher(all_tickers())
+        fetch_errors.extend(network_errors)
+
+    payload: dict[str, object] = {
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "title": "Watts Into Thoughts",
+        "subtitle": "Why intelligence per unit of energy is the number to watch",
+        "thesis": (
+            "The countries and companies that mastered hydrocarbons captured much of "
+            "the wealth of the last century. The next fortunes may belong to whoever "
+            "converts electrons into thought most efficiently."
+        ),
+        "sourceNote": (
+            "Live legs are Yahoo Finance total-return proxies, not official power or "
+            "token statistics. Research snapshots are dated figures from Nicoletos "
+            "(Aug 2026), Pal / GMI, Ribbit Capital, IEA, LBNL, Goldman, McKinsey, "
+            "and the other sources listed on each card."
+        ),
+        "northStar": {
+            "title": "Electrons into thought",
+            "lede": (
+                "Two curves lift the same ratio: manufactured energy gets cheaper, "
+                "and every chip generation produces more useful work per watt. "
+                "The listed-market echo is the compute spread."
+            ),
+            "spreads": [serialize_spread(spec, histories) for spec in SPREADS],
+        },
+        "panels": [serialize_panel(panel, histories) for panel in PANELS],
+        "errors": fetch_errors,
+    }
+
+    if use_cache and fetch is None and errors is None:
+        with _cache_lock:
+            _cache["payload"] = payload
+            _cache["expires"] = time.time() + CACHE_TTL_SECONDS
+    return payload
+
+
+def clear_cache() -> None:
+    with _cache_lock:
+        _cache["payload"] = None
+        _cache["expires"] = 0.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a **Watts** workspace (toggle next to Canvas, also at `/#watts`) that tracks the “what to watch” items from Michael Nicoletos’s *Watts Into Thoughts* note:

- Electricity prices vs oil
- Grid connection queues
- Transformer lead times
- Financing conditions
- Regions with reliable surplus power
- Where data centers get built (speed, resilience, security, regulation, preference)
- Useful intelligence per unit of energy (the north-star ratio)

Live legs are Yahoo Finance total-return proxies (power generators, uranium, grid equipment, credit, hyperscalers, silicon). Physical constraints that are not listed securities — US interconnection queue TW, median wait, token volumes, InvestAI, etc. — sit on dated research snapshot cards with sources.

North-star cards show listed-market **compute vs energy**, **power vs oil**, and **power vs gas** spreads. Each panel can be saved as a ticker list and pinned on the existing canvas when `DATABASE_URL` is set.

## API
`GET /api/watts/dashboard` (optional `?refresh=1` to bypass the 5-minute cache)

## Tests
- Unit tests for spreads, sparkline sampling, yield formatting, panel assembly, and the API route
- `python -m unittest discover -s tests` (42 tests, 6 integration skipped without Postgres)
- Live Yahoo fetch returned quotes for all 39 proxies with no errors
- Manual walkthrough of Canvas → Watts, scrolling every panel, and Refresh quotes

[North-star compute, power vs oil, and power vs gas spreads](https://cursor.com/agents/bc-01a02cd3-f0e6-7725-934c-505be1276f35/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwatts_dashboard_north_star.png)
[Intelligence per watt research cards and silicon proxies](https://cursor.com/agents/bc-01a02cd3-f0e6-7725-934c-505be1276f35/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwatts_dashboard_intelligence_panel.png)
[watts_dashboard_walkthrough.mp4](https://cursor.com/agents/bc-01a02cd3-f0e6-7725-934c-505be1276f35/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwatts_dashboard_walkthrough.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02cd3-f0e6-7725-934c-505be1276f35?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02cd3-f0e6-7725-934c-505be1276f35&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

