### PR TITLE
Fix navigation from Watts dashboard back to Canvas

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -813,28 +813,25 @@ function AppViews() {
   const { view, setView } = usePreferences();
 
   useEffect(() => {
+    let syncedInitialHash = false;
+
     const applyHash = () => {
       const hash = window.location.hash.replace(/^#/, '');
       if (hash === 'watts') {
         setView('watts');
       } else if (hash === 'canvas') {
         setView('canvas');
+      } else if (syncedInitialHash) {
+        // Browser back/forward cleared the fragment — return to the canvas.
+        setView('canvas');
       }
+      syncedInitialHash = true;
     };
+
     applyHash();
     window.addEventListener('hashchange', applyHash);
     return () => window.removeEventListener('hashchange', applyHash);
   }, [setView]);
-
-  useEffect(() => {
-    const desired = view === 'watts' ? '#watts' : '';
-    if (window.location.hash !== desired) {
-      const url = desired
-        ? `${window.location.pathname}${window.location.search}${desired}`
-        : `${window.location.pathname}${window.location.search}`;
-      window.history.replaceState(null, '', url);
-    }
-  }, [view]);
 
   if (view === 'watts') {
     return <WattsView />;

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -32,10 +32,14 @@ const scrollOptions: { value: ScrollMode; label: string; icon: ReactNode }[] = [
 ];
 
 function TopBarComponent({ variant, nodeCount = 0, busy, onRefreshAll }: TopBarProps) {
-  const { theme, setTheme, scrollMode, setScrollMode, drawerOpen, setDrawerOpen, view, setView } =
+  const { theme, setTheme, scrollMode, setScrollMode, drawerOpen, setDrawerOpen, view } =
     usePreferences();
 
   const canvas = variant === 'canvas';
+
+  function navigateTo(next: AppView) {
+    window.location.hash = next === 'watts' ? 'watts' : '';
+  }
 
   return (
     <header className="topbar">
@@ -66,7 +70,7 @@ function TopBarComponent({ variant, nodeCount = 0, busy, onRefreshAll }: TopBarP
             aria-selected={view === 'canvas'}
             aria-pressed={view === 'canvas'}
             title="Ticker canvas"
-            onClick={() => setView('canvas')}
+            onClick={() => navigateTo('canvas')}
           >
             <CanvasIcon />
             Canvas
@@ -77,7 +81,7 @@ function TopBarComponent({ variant, nodeCount = 0, busy, onRefreshAll }: TopBarP
             aria-selected={view === 'watts'}
             aria-pressed={view === 'watts'}
             title="Watts Into Thoughts dashboard"
-            onClick={() => setView('watts')}
+            onClick={() => navigateTo('watts')}
           >
             <BoltIcon />
             Watts

--- a/frontend/src/prefs/PreferencesContext.tsx
+++ b/frontend/src/prefs/PreferencesContext.tsx
@@ -73,18 +73,34 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
     setPreferences((current) => ({ ...current, ...changes }));
   }, []);
 
+  const setTheme = useCallback((theme: ThemeMode) => patch({ theme }), [patch]);
+  const setScrollMode = useCallback((scrollMode: ScrollMode) => patch({ scrollMode }), [patch]);
+  const setDrawerOpen = useCallback((drawerOpen: boolean) => patch({ drawerOpen }), [patch]);
+  const setDrawerWidth = useCallback((drawerWidth: number) => patch({ drawerWidth }), [patch]);
+  const setShowMinimap = useCallback((showMinimap: boolean) => patch({ showMinimap }), [patch]);
+  const setView = useCallback((view: AppView) => patch({ view }), [patch]);
+
   const value = useMemo<PreferencesContextValue>(
     () => ({
       ...preferences,
       resolvedTheme,
-      setTheme: (theme) => patch({ theme }),
-      setScrollMode: (scrollMode) => patch({ scrollMode }),
-      setDrawerOpen: (drawerOpen) => patch({ drawerOpen }),
-      setDrawerWidth: (drawerWidth) => patch({ drawerWidth }),
-      setShowMinimap: (showMinimap) => patch({ showMinimap }),
-      setView: (view) => patch({ view }),
+      setTheme,
+      setScrollMode,
+      setDrawerOpen,
+      setDrawerWidth,
+      setShowMinimap,
+      setView,
     }),
-    [patch, preferences, resolvedTheme],
+    [
+      preferences,
+      resolvedTheme,
+      setTheme,
+      setScrollMode,
+      setDrawerOpen,
+      setDrawerWidth,
+      setShowMinimap,
+      setView,
+    ],
   );
 
   return <PreferencesContext.Provider value={value}>{children}</PreferencesContext.Provider>;

--- a/frontend/tests/view-navigation.spec.ts
+++ b/frontend/tests/view-navigation.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test';
+
+test('navigate from Watts back to Canvas', async ({ page }) => {
+  await page.goto('/#watts');
+  await expect(page.getByRole('main', { name: 'Watts Into Thoughts dashboard' })).toBeVisible();
+
+  await page.getByRole('tab', { name: 'Canvas' }).click();
+
+  await expect(page.getByLabel('Ticker list canvas')).toBeVisible({ timeout: 5000 });
+  await expect(page.getByRole('main', { name: 'Watts Into Thoughts dashboard' })).not.toBeVisible();
+});
+
+test('browser back from Watts returns to Canvas', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByLabel('Ticker list canvas')).toBeVisible();
+
+  await page.getByRole('tab', { name: 'Watts' }).click();
+  await expect(page.getByRole('main', { name: 'Watts Into Thoughts dashboard' })).toBeVisible();
+  await expect(page).toHaveURL(/#watts$/);
+
+  await page.goBack();
+  await expect(page.getByLabel('Ticker list canvas')).toBeVisible({ timeout: 5000 });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a bug where navigating to the Watts dashboard (`/#watts`) prevented returning to the stock lists canvas via the Canvas tab or browser back button.

**Root cause:** The hash-sync effect in `AppViews` depended on `setView`, but `setView` was recreated on every preference change. Clicking Canvas called `setView('canvas')`, which re-ran the effect and immediately reset the view to `watts` while `#watts` was still in the URL.

**Fix:**
- Stabilize preference setter callbacks in `PreferencesContext` so they don't change identity when preferences update
- Drive tab switches through the URL hash (`window.location.hash`) so browser history works
- Treat a cleared hash as canvas on `hashchange` (browser back)
- Remove the view→hash `replaceState` sync effect that fought tab navigation

## Test plan

- [x] Playwright: navigate from `/#watts` to Canvas via tab
- [x] Playwright: browser back from Watts returns to Canvas
- [x] Manual: tab navigation Watts ↔ Canvas and browser back
- [x] Python unit tests pass (42 tests)

[watts_canvas_navigation_fix_demo.mp4](https://cursor.com/agents/bc-01a04625-58bb-75f7-920c-0e4e97dc5f80/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwatts_canvas_navigation_fix_demo.mp4)

[Canvas after tab click](https://cursor.com/agents/bc-01a04625-58bb-75f7-920c-0e4e97dc5f80/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_canvas_after_tab_click.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04625-58bb-75f7-920c-0e4e97dc5f80?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04625-58bb-75f7-920c-0e4e97dc5f80&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

