### PR TITLE
Recover canvas cards stuck in refresh mode after reload or view switch

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -115,16 +115,41 @@ function serializeNodes(nodes: CanvasNode[]): CanvasNode[] {
   }));
 }
 
-function getInitialCanvas(): LoadedCanvas {
+/**
+ * `loading` is only meaningful while a request is in flight. A canvas restored
+ * from storage (after a reload, or when the workspace remounts after a visit to
+ * the Watts view) has no such request, so a persisted `loading` would leave the
+ * card stuck on "Refreshing…" with its refresh button disabled.
+ */
+function withSettledStatus(node: CanvasNode): CanvasNode {
+  if (node.data.status !== 'loading') {
+    return node;
+  }
+  return { ...node, data: { ...node.data, status: 'idle' } };
+}
+
+type InitialCanvas = LoadedCanvas & {
+  /** Nodes whose refresh was cut short by the previous unmount. */
+  interruptedNodeIds: string[];
+};
+
+function getInitialCanvas(): InitialCanvas {
   const stored = loadCanvas();
   if (stored) {
-    return { ...stored, nodes: stored.nodes.map(withDefaultSize) };
+    return {
+      ...stored,
+      nodes: stored.nodes.map((node) => withDefaultSize(withSettledStatus(node))),
+      interruptedNodeIds: stored.nodes
+        .filter((node) => node.data.status === 'loading')
+        .map((node) => node.id),
+    };
   }
   return {
     nodes: [],
     edges: [] as Edge[],
     viewport: undefined,
     rawViewport: undefined,
+    interruptedNodeIds: [],
   };
 }
 
@@ -530,6 +555,22 @@ function Workspace() {
       return alive.length === current.length ? current : alive;
     });
   }, [listsStatus, listsById, setNodes]);
+
+  // Finish refreshes that were in flight when the canvas last unmounted. This
+  // waits for the list catalog because `refreshNode` reads tickers from it.
+  const resumeAttempted = useRef(false);
+  useEffect(() => {
+    if (resumeAttempted.current || listsStatus !== 'ready') {
+      return;
+    }
+    resumeAttempted.current = true;
+    for (const nodeId of initialCanvas.interruptedNodeIds) {
+      const node = nodesRef.current.find((entry) => entry.id === nodeId);
+      if (node && listsById[node.data.listId] !== undefined) {
+        void refreshNode(nodeId);
+      }
+    }
+  }, [initialCanvas.interruptedNodeIds, listsById, listsStatus, refreshNode]);
 
   // ------------------------------------------------------------------ rendering
 

--- a/frontend/tests/refresh-recovery.spec.ts
+++ b/frontend/tests/refresh-recovery.spec.ts
@@ -1,0 +1,253 @@
+import { expect, test, type Page, type Route } from '@playwright/test';
+
+const CANVAS_KEY_V3 = 'xscout.canvas.v3';
+const PREFS_KEY = 'xscout.prefs.v1';
+
+const listFixture = { id: 'list-1', name: 'Saved list', tickers: ['AAPL'] };
+
+const storedNode = {
+  id: 'node-1',
+  type: 'tickerList',
+  position: { x: 120, y: 120 },
+  style: { width: 560, height: 300 },
+  data: {
+    listId: listFixture.id,
+    name: listFixture.name,
+    tickers: listFixture.tickers,
+    rows: [],
+    errors: [],
+    status: 'idle',
+    updatedAt: 1_700_000_000_000,
+  },
+};
+
+const performanceResponse = {
+  rows: [
+    {
+      ticker: 'AAPL',
+      price: '$100.00',
+      marketCap: '$1.00T',
+      change1d: '+1.0%',
+      change1dClass: 'positive',
+      change5d: '+1.0%',
+      change5dClass: 'positive',
+      change2w: '+1.0%',
+      change2wClass: 'positive',
+      change1m: '+1.0%',
+      change1mClass: 'positive',
+      change3m: '+1.0%',
+      change3mClass: 'positive',
+      change6m: '+1.0%',
+      change6mClass: 'positive',
+      change1y: '+1.0%',
+      change1yClass: 'positive',
+      change5y: '+1.0%',
+      change5yClass: 'positive',
+    },
+  ],
+  errors: [],
+};
+
+type PerformanceRouting = {
+  /** Number of performance requests seen so far. */
+  count: () => number;
+  /** Releases every request currently parked by `hold()`. */
+  release: () => Promise<void>;
+  /** Parks subsequent requests until `release()` is called. */
+  hold: () => void;
+  /** Lets subsequent requests resolve immediately. */
+  passthrough: () => void;
+};
+
+async function routePerformance(page: Page): Promise<PerformanceRouting> {
+  let holding = false;
+  let count = 0;
+  const parked: Route[] = [];
+
+  await page.route('**/api/watchlists/performance', async (route) => {
+    count += 1;
+    if (holding) {
+      parked.push(route);
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(performanceResponse),
+    });
+  });
+
+  return {
+    count: () => count,
+    hold: () => {
+      holding = true;
+    },
+    passthrough: () => {
+      holding = false;
+    },
+    release: async () => {
+      holding = false;
+      const pending = parked.splice(0);
+      for (const route of pending) {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(performanceResponse),
+        });
+      }
+    },
+  };
+}
+
+async function seedStorage(page: Page, nodeStatus: string) {
+  await page.addInitScript(
+    ({ keys, node, status }) => {
+      if (window.sessionStorage.getItem('xscout.test.seeded')) {
+        return;
+      }
+      window.sessionStorage.setItem('xscout.test.seeded', '1');
+      window.localStorage.clear();
+      window.localStorage.setItem(
+        keys.preferences,
+        JSON.stringify({
+          theme: 'light',
+          scrollMode: 'zoom',
+          drawerOpen: false,
+          drawerWidth: 304,
+          showMinimap: false,
+        }),
+      );
+      window.localStorage.setItem(
+        keys.canvas,
+        JSON.stringify({
+          nodes: [{ ...node, data: { ...node.data, status } }],
+          edges: [],
+        }),
+      );
+    },
+    {
+      keys: { canvas: CANVAS_KEY_V3, preferences: PREFS_KEY },
+      node: storedNode,
+      status: nodeStatus,
+    },
+  );
+}
+
+async function routeLists(page: Page) {
+  await page.route('**/api/ticker-lists', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ lists: [listFixture] }),
+    }),
+  );
+}
+
+async function readStoredStatus(page: Page): Promise<string | undefined> {
+  return page.evaluate((key) => {
+    const raw = window.localStorage.getItem(key);
+    if (!raw) {
+      return undefined;
+    }
+    return JSON.parse(raw).nodes?.[0]?.data?.status as string | undefined;
+  }, CANVAS_KEY_V3);
+}
+
+function nodeRefreshButton(page: Page) {
+  return page.getByRole('button', { name: 'Refresh performance data' });
+}
+
+test('a card whose refresh was interrupted before reload recovers', async ({ page }) => {
+  await seedStorage(page, 'loading');
+  await routeLists(page);
+  const performance = await routePerformance(page);
+
+  await page.goto('/');
+  await page.waitForSelector('.react-flow__node');
+
+  // The card is not left on "Refreshing…" with a disabled refresh button.
+  await expect(nodeRefreshButton(page)).toBeEnabled({ timeout: 5_000 });
+  await expect(page.locator('.ticker-node')).not.toHaveClass(/is-loading/);
+  await expect(page.locator('.ticker-node__meta')).not.toHaveText('Refreshing…');
+  await expect(page.getByRole('button', { name: /Refresh all/ })).toBeEnabled();
+
+  // The interrupted refresh is resumed so the card ends up with fresh rows.
+  await expect(page.locator('.ticker-node')).toContainText('AAPL');
+  expect(performance.count()).toBeGreaterThanOrEqual(1);
+
+  // Storage no longer carries the stale in-flight marker.
+  await page.waitForTimeout(600);
+  expect(await readStoredStatus(page)).toBe('ready');
+});
+
+test('reloading mid-refresh does not leave the card stuck', async ({ page }) => {
+  await seedStorage(page, 'idle');
+  await routeLists(page);
+  const performance = await routePerformance(page);
+
+  await page.goto('/');
+  await page.waitForSelector('.react-flow__node');
+  await expect(nodeRefreshButton(page)).toBeEnabled();
+
+  performance.hold();
+  await nodeRefreshButton(page).click();
+  await expect(page.locator('.ticker-node')).toHaveClass(/is-loading/);
+  await expect(nodeRefreshButton(page)).toBeDisabled();
+
+  // Wait for the debounced save so storage reflects the in-flight refresh
+  // exactly as it would if the tab were closed or reloaded at this moment.
+  await page.waitForTimeout(600);
+
+  performance.passthrough();
+  await page.reload();
+  await page.waitForSelector('.react-flow__node');
+
+  await expect(nodeRefreshButton(page)).toBeEnabled({ timeout: 5_000 });
+  await expect(page.locator('.ticker-node')).not.toHaveClass(/is-loading/);
+  await expect(page.locator('.ticker-node')).toContainText('AAPL');
+});
+
+test('switching to the Watts view mid-refresh and back does not leave the card stuck', async ({
+  page,
+}) => {
+  await seedStorage(page, 'idle');
+  await routeLists(page);
+  const performance = await routePerformance(page);
+  await page.route('**/api/watts/dashboard**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        generatedAt: '2026-01-01T00:00:00Z',
+        title: 'Watts',
+        subtitle: '',
+        thesis: '',
+        sourceNote: '',
+        northStar: { title: 'North star', lede: '', spreads: [] },
+        panels: [],
+        errors: [],
+      }),
+    }),
+  );
+
+  await page.goto('/');
+  await page.waitForSelector('.react-flow__node');
+
+  performance.hold();
+  await nodeRefreshButton(page).click();
+  await expect(page.locator('.ticker-node')).toHaveClass(/is-loading/);
+
+  await page.getByRole('tab', { name: 'Watts' }).click();
+  await expect(page.locator('.react-flow__node')).toHaveCount(0);
+
+  // The original request finishes while the canvas is unmounted.
+  await performance.release();
+  performance.passthrough();
+
+  await page.getByRole('tab', { name: 'Canvas' }).click();
+  await page.waitForSelector('.react-flow__node');
+
+  await expect(nodeRefreshButton(page)).toBeEnabled({ timeout: 5_000 });
+  await expect(page.locator('.ticker-node')).not.toHaveClass(/is-loading/);
+  await expect(page.locator('.ticker-node')).toContainText('AAPL');
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Ticker list cards could get stuck showing "Refreshing…" with a spinning, disabled refresh button, and the top bar "Refresh all" button greyed out. Nothing on the card would ever clear it.

## Root cause

`serializeNodes` in `frontend/src/App.tsx` persists each node's `status` to `localStorage` along with the rest of its data. If the canvas is torn down while a refresh is in flight, `status: 'loading'` is saved. When the canvas is restored there is no request in flight to complete it, so the card stays in loading state indefinitely.

Two easy ways to trigger it:

- Press refresh (or "Refresh all" / `R`) and reload or close the tab before the response arrives.
- Press refresh and switch to the Watts tab before the response arrives. `Workspace` unmounts, the response lands on the unmounted component, and coming back to Canvas rebuilds the nodes from `localStorage`, which still says `loading`.

## Fix

- `getInitialCanvas` now normalises any persisted `loading` status to `idle` so a restored card is immediately interactive again.
- The ids of those interrupted nodes are recorded and, once the list catalog is ready, their refresh is resumed so the card ends up with fresh rows rather than silently keeping stale ones.

## Before / after

Same scenario in both: click refresh while the performance request is held open, wait for the debounced save, reload.

Before (master): card restored as stuck, refresh button disabled, "Refresh all" disabled.

[Before fix: card stuck on Refreshing after reload](https://cursor.com/agents/bc-01a067ae-3ef0-70c7-97a5-717409a2b3f8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbefore_fix_card_stuck_refreshing_after_reload.png)

After: card recovers and the interrupted refresh completes.

[After fix: card recovers and shows fresh rows](https://cursor.com/agents/bc-01a067ae-3ef0-70c7-97a5-717409a2b3f8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_fix_card_recovers_and_resumes_refresh.png)

## Tests

New Playwright spec `frontend/tests/refresh-recovery.spec.ts` covers three scenarios; all fail on `master` and pass with this change:

- storage seeded with `status: 'loading'` (an already-stuck user)
- refresh held open, then page reload
- refresh held open, switch to Watts and back

Full Playwright suite (8 tests) and Python unit tests (42, 6 DB-integration skips) pass.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a067ae-3ef0-70c7-97a5-717409a2b3f8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a067ae-3ef0-70c7-97a5-717409a2b3f8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

