### PR TITLE
Cover multi-card Refresh all interrupted by a view switch

### DIFF
--- a/frontend/tests/refresh-recovery.spec.ts
+++ b/frontend/tests/refresh-recovery.spec.ts
@@ -99,9 +99,26 @@ async function routePerformance(page: Page): Promise<PerformanceRouting> {
   };
 }
 
-async function seedStorage(page: Page, nodeStatus: string) {
+function listFixtures(count: number) {
+  return Array.from({ length: count }, (_, index) =>
+    index === 0
+      ? listFixture
+      : { id: `list-${index + 1}`, name: `Saved list ${index + 1}`, tickers: ['AAPL'] },
+  );
+}
+
+function nodeFixtures(count: number, status: string) {
+  return listFixtures(count).map((list, index) => ({
+    ...storedNode,
+    id: index === 0 ? storedNode.id : `node-${index + 1}`,
+    position: { x: 120 + (index % 2) * 600, y: 120 + Math.floor(index / 2) * 340 },
+    data: { ...storedNode.data, listId: list.id, name: list.name, status },
+  }));
+}
+
+async function seedStorage(page: Page, nodeStatus: string, count = 1) {
   await page.addInitScript(
-    ({ keys, node, status }) => {
+    ({ keys, nodes }) => {
       if (window.sessionStorage.getItem('xscout.test.seeded')) {
         return;
       }
@@ -119,26 +136,41 @@ async function seedStorage(page: Page, nodeStatus: string) {
       );
       window.localStorage.setItem(
         keys.canvas,
-        JSON.stringify({
-          nodes: [{ ...node, data: { ...node.data, status } }],
-          edges: [],
-        }),
+        JSON.stringify({ nodes, edges: [] }),
       );
     },
     {
       keys: { canvas: CANVAS_KEY_V3, preferences: PREFS_KEY },
-      node: storedNode,
-      status: nodeStatus,
+      nodes: nodeFixtures(count, nodeStatus),
     },
   );
 }
 
-async function routeLists(page: Page) {
+async function routeLists(page: Page, count = 1) {
   await page.route('**/api/ticker-lists', (route) =>
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ lists: [listFixture] }),
+      body: JSON.stringify({ lists: listFixtures(count) }),
+    }),
+  );
+}
+
+async function routeWatts(page: Page) {
+  await page.route('**/api/watts/dashboard**', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        generatedAt: '2026-01-01T00:00:00Z',
+        title: 'Watts',
+        subtitle: '',
+        thesis: '',
+        sourceNote: '',
+        northStar: { title: 'North star', lede: '', spreads: [] },
+        panels: [],
+        errors: [],
+      }),
     }),
   );
 }
@@ -213,22 +245,7 @@ test('switching to the Watts view mid-refresh and back does not leave the card s
   await seedStorage(page, 'idle');
   await routeLists(page);
   const performance = await routePerformance(page);
-  await page.route('**/api/watts/dashboard**', (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({
-        generatedAt: '2026-01-01T00:00:00Z',
-        title: 'Watts',
-        subtitle: '',
-        thesis: '',
-        sourceNote: '',
-        northStar: { title: 'North star', lede: '', spreads: [] },
-        panels: [],
-        errors: [],
-      }),
-    }),
-  );
+  await routeWatts(page);
 
   await page.goto('/');
   await page.waitForSelector('.react-flow__node');
@@ -250,4 +267,47 @@ test('switching to the Watts view mid-refresh and back does not leave the card s
   await expect(nodeRefreshButton(page)).toBeEnabled({ timeout: 5_000 });
   await expect(page.locator('.ticker-node')).not.toHaveClass(/is-loading/);
   await expect(page.locator('.ticker-node')).toContainText('AAPL');
+});
+
+// With several cards, "Refresh all" fans out one request per card. A single
+// Gunicorn worker answers them one at a time, so some cards are usually still
+// waiting when the user navigates away; every one of them has to recover.
+test('every card recovers when Refresh all is interrupted by a view switch', async ({
+  page,
+}) => {
+  const count = 5;
+  await seedStorage(page, 'idle', count);
+  await routeLists(page, count);
+  const performance = await routePerformance(page);
+  await routeWatts(page);
+
+  await page.goto('/');
+  await expect(page.locator('.react-flow__node')).toHaveCount(count);
+
+  performance.hold();
+  await page.getByRole('button', { name: 'Refresh all' }).click();
+  await expect(page.locator('.ticker-node.is-loading')).toHaveCount(count);
+  await expect(page.getByRole('button', { name: 'Refreshing…' })).toBeDisabled();
+
+  await page.getByRole('tab', { name: 'Watts' }).click();
+  await expect(page.locator('.react-flow__node')).toHaveCount(0);
+
+  // Every original response lands while the canvas is unmounted, so none of
+  // them can update a card.
+  await performance.release();
+  performance.passthrough();
+
+  await page.getByRole('tab', { name: 'Canvas' }).click();
+  await expect(page.locator('.react-flow__node')).toHaveCount(count);
+
+  await expect(page.locator('.ticker-node.is-loading')).toHaveCount(0, { timeout: 10_000 });
+  await expect(nodeRefreshButton(page)).toHaveCount(count);
+  for (const button of await nodeRefreshButton(page).all()) {
+    await expect(button).toBeEnabled();
+  }
+  await expect(page.locator('.ticker-node__meta').filter({ hasText: 'Refreshing…' })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: 'Refresh all' })).toBeEnabled();
+  for (const card of await page.locator('.ticker-node').all()) {
+    await expect(card).toContainText('AAPL');
+  }
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #18, which fixed cards getting stuck on "Refreshing…". This adds regression coverage for the way the bug was actually reported: it shows up mostly when there are several lists on the canvas.

## Why more lists make it worse

"Refresh all" fans out one `/api/watchlists/performance` request per card, and the production Gunicorn config (`Procfile`, `Dockerfile`) is a single sync worker, so those requests are answered one at a time. Eight small lists took ~10 s locally; with Yahoo throttling it is longer. Any navigation in that window strands every card still waiting, and a single stranded card also disables "Refresh all" for the whole canvas.

Reproduced end to end against the real Gunicorn backend on the code before #18: 8 lists, click "Refresh all", switch to Watts after ~1.5 s, come back. All 8 backend responses returned 200, yet 6 of 8 cards stayed on "Refreshing…" for the full 3 minute observation window and "Refresh all" stayed disabled.

Same run with the fix from #18: all 8 cards recover (7 were interrupted and resumed).

[eight_lists_refresh_all_watts_roundtrip_recovers.mp4](https://cursor.com/agents/bc-01a067ae-3ef0-70c7-97a5-717409a2b3f8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Feight_lists_refresh_all_watts_roundtrip_recovers.mp4)

[All eight cards settled after the Watts round-trip](https://cursor.com/agents/bc-01a067ae-3ef0-70c7-97a5-717409a2b3f8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_fix_eight_lists_watts_roundtrip_all_settled.png)

## Change

`frontend/tests/refresh-recovery.spec.ts`: the fixtures now support N cards/lists, the Watts dashboard mock is shared, and a new case seeds five cards, holds every "Refresh all" request open, switches to Watts and back, and asserts that every card leaves the loading state, every refresh button is enabled, "Refresh all" is enabled and every card shows rows.

The new case fails on the pre-#18 `App.tsx` (5 cards still `is-loading` after 10 s) and passes on `master`. Full Playwright suite: 9 passed.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a067ae-3ef0-70c7-97a5-717409a2b3f8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a067ae-3ef0-70c7-97a5-717409a2b3f8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

